### PR TITLE
(bugfix) pci failover associate message in html

### DIFF
--- a/client/app/cloud/project/compute/infrastructure/cloud-project-compute-infrastructure.controller.js
+++ b/client/app/cloud/project/compute/infrastructure/cloud-project-compute-infrastructure.controller.js
@@ -946,11 +946,13 @@ angular.module("managerApp").controller("CloudProjectComputeInfrastructureCtrl",
                         return CloudProjectComputeInfrastructureOrchestrator.attachIptoVm(connectedIp, connectedVm).then(function () {
                             $rootScope.$broadcast('highlighed-element.hide');
                             self.model.currentLinkEdit = null;
-                            var successMessage = $translate.instant('cpci_ip_attach_success', {ip : connectedIp.ip, instance : connectedVm.name});
+                            var successMessage = { text: $translate.instant('cpci_ip_attach_success', {ip : connectedIp.ip, instance : connectedVm.name}) };
                             if (connectedIp.type === "failover" && connectedVm.image){
                                 var distribution = connectedVm.image.distribution || URLS.guides.ip_failover.defaultDistribution;
-                                successMessage += ' ' + $translate.instant('cpci_ip_attach_failover_help',
-                                    {link : URLS.guides.ip_failover[self.user.ovhSubsidiary][distribution]});
+                                successMessage = {
+                                    textHtml: successMessage.text + ' ' + $translate.instant('cpci_ip_attach_failover_help',
+                                        {link : URLS.guides.ip_failover[self.user.ovhSubsidiary][distribution]})
+                                };
                             }
                             CloudMessage.success(successMessage);
                         }, function (err) {


### PR DESCRIPTION
when associating a failover IP to a VM, message would display non interpreted html