### PR TITLE
Bugfix import ssh from other regions

### DIFF
--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.controller.js
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.controller.js
@@ -966,7 +966,11 @@ angular.module("managerApp")
 
     $scope.$watch('VmAddEditCtrl.model.sshKeyId', function (value, oldValue) {
         if  (value) {
-            self.vmInEdition.sshKey = _.find(self.panelsData.sshKeys, { id: value });
+            var sshkey = _.find(self.panelsData.sshKeys, { id: value });
+            if (!sshkey || !sshkey.availableOnRegion) {
+                return;
+            }
+            self.vmInEdition.sshKey = sshkey
 
             if (value !== oldValue) {
                 self.backToMenu();

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.html
@@ -1533,9 +1533,7 @@
                                             <input type="radio"
                                                     value="{{::sshKey.id}}"
                                                     name="ssh_choice"
-                                                    data-ovh-stop-event="click"
-                                                    data-ng-disabled="VmAddEditCtrl.sshKeyDeletedId"
-                                                    data-ng-model="VmAddEditCtrl.model.sshKeyId">
+                                                    >
                                         </flat-radio>
                                     </td>
 


### PR DESCRIPTION
## Bugfix import ssh from other regions
When I create an instance, if I select a ssh key not in the selected region, it doesn't work if I click on the checkbox. It works if I click on the label.
