### PR TITLE
fixed bug UXMCLOUD-1844: multi and range port values are discarded

### DIFF
--- a/client/app/iplb/frontends/iplb-frontends-edit.controller.js
+++ b/client/app/iplb/frontends/iplb-frontends-edit.controller.js
@@ -192,7 +192,9 @@ class IpLoadBalancerFrontendsEditCtrl {
                 break;
             default: break;
         }
-        frontend.port = parseInt(frontend.port, 10);
+        //port can not be integer because it can be simple(80), range (1000-2000) or multi (80,443)
+        //converting it to integer will cause problem if it is range or multi
+        //frontend.port = parseInt(frontend.port, 10);
         this.frontend = angular.copy(frontend);
         return frontend;
     }

--- a/client/app/iplb/frontends/iplb-frontends-edit.controller.js
+++ b/client/app/iplb/frontends/iplb-frontends-edit.controller.js
@@ -192,9 +192,6 @@ class IpLoadBalancerFrontendsEditCtrl {
                 break;
             default: break;
         }
-        //port can not be integer because it can be simple(80), range (1000-2000) or multi (80,443)
-        //converting it to integer will cause problem if it is range or multi
-        //frontend.port = parseInt(frontend.port, 10);
         this.frontend = angular.copy(frontend);
         return frontend;
     }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Title
Merge bugfix/UXMCLOUD-1844 branch to develop


### Description of the Change

fixed bug https://interne.ovh.net/projects/browse/UXMCLOUD-1844
removed converting a string to an integer which was ignoring multi and range ports

### Benefits

users will be able to enter multi and range port like 87.443 and 1000-2000

### Possible Drawbacks

none

### Applicable Issues

none
