### PR TITLE
Bugfix(debug): Remove debug

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,8 +47,7 @@ module.exports = function (grunt) {
             },
             dev: {
                 options: {
-                    script: "<%= yeoman.server %>",
-                    debug: true
+                    script: "<%= yeoman.server %>"
                 }
             },
             prod: {


### PR DESCRIPTION
## Remove debug mode for express

### Description of the Change
Remove debug mode for express, as it is not used in our other apps.

### Benefits
Express now working for version v8.0.0 of node and above.

### Possible Drawbacks
No debug more. It was not used.

### Applicable Issues
Resolves #360
