### PR TITLE
Helper text UI alignment and Alerts count update in Streams page

### DIFF
--- a/client/app/dbaas/logs/detail/streams/alerts/add/alerts-add.html
+++ b/client/app/dbaas/logs/detail/streams/alerts/add/alerts-add.html
@@ -1,7 +1,7 @@
 <div class="cui-page__content">
     <oui-back-button class="back_button_inline_text"></oui-back-button>
-    <span class="oui-header_3" data-translate="{{ 'add_alert_title_' + ctrl.alertType.toLowerCase() }}"></span>
-    <p class="oui-paragraph" data-translate="{{ 'add_alert_description_' + ctrl.alertType.toLowerCase() }}"></p>
+    <span class="oui-header_3" data-translate="{{ ::'add_alert_title_' + ctrl.alertType.toLowerCase() }}"></span>
+    <p class="oui-paragraph" data-translate="{{ ::'add_alert_description_' + ctrl.alertType.toLowerCase() }}"></p>
 
     <form novalidate name="ctrl.form">
         <div class="oui-field" data-ng-class="{'oui-field_error': ctrl.form.$submitted && ctrl.form.alert_title.$invalid}">
@@ -16,8 +16,8 @@
                             data-ng-maxlength="ctrl.LogsStreamsAlertsAddConstant.TITLE_MAX_LENGTH"
                             autofocus
                             required />
+                    <div class="oui-field-helper mb-0 ml-0" data-translate="add_alert_title_field_description"></div>
                 </div>
-                <div class="oui-field-helper" data-translate="add_alert_title_field_description"></div>
             </div>
         </div>
 
@@ -32,8 +32,8 @@
                             data-ng-minlength="ctrl.LogsStreamsAlertsAddConstant.FIELD_MIN_LENGTH"
                             data-ng-maxlength="ctrl.LogsStreamsAlertsAddConstant.FIELD_MAX_LENGTH"
                             required />
+                    <div class="oui-field-helper mb-0 ml-0" data-translate="add_alert_field_field_description"></div>
                 </div>
-                <div class="oui-field-helper" data-translate="add_alert_field_field_description"></div>
             </div>
         </div>
 
@@ -48,8 +48,8 @@
                                 data-ng-minlength="ctrl.LogsStreamsAlertsAddConstant.VALUE_MIN_LENGTH"
                                 data-ng-maxlength="ctrl.LogsStreamsAlertsAddConstant.VALUE_MAX_LENGTH"
                                 required />
+                        <div class="oui-field-helper mb-0 ml-0" data-translate="add_alert_value_field_description"></div>
                     </div>
-                    <div class="oui-field-helper" data-translate="add_alert_value_field_description"></div>
                 </div>
             </div>
 
@@ -61,30 +61,31 @@
                         id="time_period"
                         name="time_period"
                         model="ctrl.alert.time"
+                        class="numeric_without_bottom_margin"
                         min="ctrl.LogsStreamsAlertsAddConstant.TIME_PERIOD_MIN_IN_SECONDS"
                         max="ctrl.LogsStreamsAlertsAddConstant.TIME_PERIOD_MAX_IN_SECONDS"
                         required>
-                    </oui-numeric>
-                    <div class="oui-field-helper" data-translate="add_alert_time_period_field_description"></div>
+                    </oui-numeric>                    
                 </div>
+                <div class="oui-field-helper mt-2 mb-4 ml-0" data-translate="add_alert_time_period_field_description"></div>
             </div>
 
             <div class="oui-field">
                 <label for="threshold_type" class="oui-label" data-translate="add_alert_threshold_type_field"></label>
                 <div class="oui-field__content">
-                    <div class="oui-field-control oui-field-control_4">
+                    <div class="oui-field-control oui-field-control_4 mb-0">
                         <div class="oui-select">
                             <select class="oui-select__input"
                                 name="threshold_type"
                                 id="threshold_type"
                                 data-ng-model="ctrl.alert.thresholdType">
-                                <option data-ng-repeat="thresholdType in ctrl.getThresholdTypes()" value="{{thresholdType}}" data-translate="{{ 'add_alert_threshold_type_' + thresholdType.toLowerCase() }}"></option>
+                                <option data-ng-repeat="thresholdType in ctrl.getThresholdTypes()" value="{{::thresholdType}}" data-translate="{{ ::'add_alert_threshold_type_' + thresholdType.toLowerCase() }}"></option>
                             </select>
                             <i class="oui-icon oui-icon-chevron-down" aria-hidden="true"></i>
-                        </div>
+                        </div>                        
                     </div>
-                    <div class="oui-field-helper" data-translate="{{ 'add_alert_threshold_type_field_description_' + ctrl.alertType.toLowerCase() }}"></div>
                 </div>
+                <div class="oui-field-helper mb-4 ml-0" data-translate="{{ ::'add_alert_threshold_type_field_description_' + ctrl.alertType.toLowerCase() }}"></div>
             </div>
 
             <div class="oui-field" data-ng-class="{'oui-field_error': ctrl.form.$submitted && ctrl.form.threshold.$invalid}">
@@ -94,30 +95,31 @@
                         id="threshold"
                         name="threshold"
                         model="ctrl.alert.threshold"
+                        class="numeric_without_bottom_margin"
                         min="ctrl.LogsStreamsAlertsAddConstant.THRESHOLD_MIN"
                         max="ctrl.LogsStreamsAlertsAddConstant.THRESHOLD_MAX"
                         required>
                     </oui-numeric>
-                    <div class="oui-field-helper" data-translate="add_alert_threshold_field_description"></div>
                 </div>
+                <div class="oui-field-helper mt-2 mb-4 ml-0" data-translate="add_alert_threshold_field_description"></div>
             </div>
 
             <div data-ng-if="ctrl.alertType === 'FIELD_VALUE'" class="oui-field">
                 <label for="constraint_type" class="oui-label" data-translate="add_alert_constraint_type_field"></label>
                 <div class="oui-field__content">
-                    <div class="oui-field-control oui-field-control_4">
+                    <div class="oui-field-control oui-field-control_4 mb-0">
                         <div class="oui-select">
                             <select class="oui-select__input"
                                 name="constraint_type"
                                 id="constraint_type"
                                 data-ng-model="ctrl.alert.constraintType">
-                                <option data-ng-repeat="constraintType in ctrl.getConstraintTypes()" value="{{constraintType}}" data-translate="{{ 'add_alert_constraint_type_' + constraintType.toLowerCase() }}"></option>
+                                <option data-ng-repeat="constraintType in ctrl.getConstraintTypes()" value="{{::constraintType}}" data-translate="{{ ::'add_alert_constraint_type_' + constraintType.toLowerCase() }}"></option>
                             </select>
                             <i class="oui-icon oui-icon-chevron-down" aria-hidden="true"></i>
                         </div>
                     </div>
-                    <div class="oui-field-helper" data-translate="add_alert_constraint_type_field_description"></div>
                 </div>
+                <div class="oui-field-helper mb-4 ml-0" data-translate="add_alert_constraint_type_field_description"></div>
             </div>
         </div>
 
@@ -128,12 +130,13 @@
                     id="grace_period"
                     name="grace_period"
                     model="ctrl.alert.grace"
+                    class="numeric_without_bottom_margin"
                     min="ctrl.LogsStreamsAlertsAddConstant.GRACE_PERIOD_MIN_IN_MINUTES"
                     max="ctrl.LogsStreamsAlertsAddConstant.GRACE_PERIOD_MAX_IN_MINUTES"
                     required>
                 </oui-numeric>
-                <div class="oui-field-helper" data-translate="add_alert_grace_period_field_description"></div>
             </div>
+            <div class="oui-field-helper mt-2 mb-4 ml-0" data-translate="add_alert_grace_period_field_description"></div>
         </div>
 
         <div class="oui-field" data-ng-class="{'oui-field_error': ctrl.form.$submitted && ctrl.form.accumulation.$invalid}">
@@ -143,12 +146,13 @@
                     id="accumulation"
                     name="accumulation"
                     model="ctrl.alert.backlog"
+                    class="numeric_without_bottom_margin"
                     min="ctrl.LogsStreamsAlertsAddConstant.BACKLOG_MIN"
                     max="ctrl.LogsStreamsAlertsAddConstant.BACKLOG_MAX"
                     required>
                 </oui-numeric>
-                <div class="oui-field-helper" data-translate="add_alert_accumulation_field_description"></div>
             </div>
+            <div class="oui-field-helper mt-2 mb-4 ml-0" data-translate="add_alert_accumulation_field_description"></div>
         </div>
 
         <div class="oui-field pb-4">
@@ -157,8 +161,8 @@
                     <oui-checkbox model="ctrl.alert.repeatNotificationsEnabled"
                         id="notification"
                         name="notification"
-                        text="{{'add_alert_notification_field' | translate}}"
-                        description="{{'add_alert_notification_field_description' | translate}}">
+                        text="{{::'add_alert_notification_field' | translate}}"
+                        description="{{::'add_alert_notification_field_description' | translate}}">
                     </oui-checkbox>
                 </div>
             </div>
@@ -168,14 +172,14 @@
             <oui-spinner data-ng-show="ctrl.addingAlert.loading"></oui-spinner>
             <div data-ng-hide="ctrl.addingAlert.loading">
                 <oui-button
-                    text="{{'common_create' | translate}}"
+                    text="{{::'common_create' | translate}}"
                     variant="primary"
                     type="submit"
                     on-click="ctrl.addAlert()"
                 ></oui-button>
             
                 <oui-button
-                    text="{{'common_cancel' | translate}}"
+                    text="{{::'common_cancel' | translate}}"
                     variant="link"
                     on-click="ctrl.cancel()"
                 ></oui-button>

--- a/client/app/dbaas/logs/detail/streams/alerts/add/translations/Messages_en_GB.xml
+++ b/client/app/dbaas/logs/detail/streams/alerts/add/translations/Messages_en_GB.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-    <translation id="add_alert_title_message_count">Create a counter condition</translation>
-    <translation id="add_alert_title_field_value">Create a numeric value condition</translation>
-    <translation id="add_alert_title_field_content_value">Create a textual content condition</translation>
+    <translation id="add_alert_title_message_count">Add a message count condition</translation>
+    <translation id="add_alert_title_field_value">Add a field aggregation condition</translation>
+    <translation id="add_alert_title_field_content_value">Add a field content condition</translation>
     
     <translation id="add_alert_description_message_count">This condition is triggered when the number of messages is greater than or less than the threshold set in a given period</translation>
     <translation id="add_alert_description_field_value">This condition is triggered when the aggregated value of a field is higher or lower than a defined threshold in a given period of time</translation>

--- a/client/app/dbaas/logs/detail/streams/logs-streams.service.js
+++ b/client/app/dbaas/logs/detail/streams/logs-streams.service.js
@@ -1,6 +1,5 @@
 class LogsStreamsService {
-    constructor ($q, $translate, OvhApiDbaas, ServiceHelper, CloudPoll,
-                 LogsOptionsService, ControllerHelper, UrlHelper, CloudMessage, LogStreamsConstants) {
+    constructor ($q, $translate, CloudMessage, CloudPoll, ControllerHelper, LogsOptionsService, LogsStreamsAlertsService, LogStreamsConstants, OvhApiDbaas, ServiceHelper, UrlHelper) {
         this.$q = $q;
         this.$translate = $translate;
         this.ServiceHelper = ServiceHelper;
@@ -11,6 +10,7 @@ class LogsStreamsService {
         this.OperationApiService = OvhApiDbaas.Logs().Operation().Lexi();
         this.CloudPoll = CloudPoll;
         this.LogsOptionsService = LogsOptionsService;
+        this.LogsStreamsAlertsService = LogsStreamsAlertsService;
         this.ControllerHelper = ControllerHelper;
         this.UrlHelper = UrlHelper;
         this.CloudMessage = CloudMessage;
@@ -179,20 +179,6 @@ class LogsStreamsService {
     }
 
     /**
-     * returns all notifications configured for a given stream
-     *
-     * @param {any} serviceName
-     * @param {any} streamId
-     * @returns promise which will be resolve to array of notifications
-     * @memberof LogsStreamsService
-     */
-    getNotifications (serviceName, streamId) {
-        return this.StreamsApiService.notifications({ serviceName, streamId })
-            .$promise
-            .catch(this.ServiceHelper.errorHandler("logs_streams_notifications_get_error"));
-    }
-
-    /**
      * returns all archives configured for a given stream
      *
      * @param {any} serviceName
@@ -332,7 +318,7 @@ class LogsStreamsService {
         stream.info.notifications = [];
         stream.info.archives = [];
         // asynchronously fetch all notification of a stream
-        this.getNotifications(serviceName, stream.info.streamId)
+        this.LogsStreamsAlertsService.getAlertIds(serviceName, stream.info.streamId)
             .then(notifications => {
                 stream.info.notifications = notifications;
             });

--- a/client/app/dbaas/logs/detail/streams/translations/Messages_en_GB.xml
+++ b/client/app/dbaas/logs/detail/streams/translations/Messages_en_GB.xml
@@ -50,7 +50,6 @@
     <translation id="logs_stream_get_error">An error has occurred while retrieving data stream: {{message}}</translation>
     <translation id="logs_streams_get_error">An error has occurred while retrieving data streams: {{message}}</translation>
     <translation id="logs_streams_quota_get_error">An error has occurred while retrieving data stream quota: {{message}}</translation>
-    <translation id="logs_streams_notifications_get_error">An error has occurred while retrieving data stream notifiations: {{message}}</translation>
     <translation id="logs_streams_archives_get_error">An error has occurred while retrieving data stream notifiations: {{message}}</translation>
     <translation id="logs_streams_find_token_error">Token not found for stream {{stream}}.</translation>
     <translation id="logs_streams_copy_token_error">Your browser does not support copy to clipboard. Please upgrade browser to latest version. Here is the token value to enter for stream {{stream}}: {{token_value}}</translation>


### PR DESCRIPTION
### Requirements

* The helper text for the input controls must be below the control and not to the right side of it
* The Alerts count should refresh in the stream page, if it gets modified in the alerts page

## Title of the Pull Requests <!-- required -->
Helper text UI alignment and Alerts count update in Streams page

### Description of the Change

* The helper text has been moved to the bottom of the input controls in the add alerts page
* The streams service now re-uses the method from alert service, so that the updated cache is used, while getting the alerts in the stream page.
