### PR TITLE
Notifications clean-up and scroll to top

### DIFF
--- a/client/app/dbaas/logs/detail/streams/archives/streams-archives.service.js
+++ b/client/app/dbaas/logs/detail/streams/archives/streams-archives.service.js
@@ -82,8 +82,7 @@ class LogsStreamsArchivesService {
             streamId,
             archiveId,
             expirationInSeconds: this.LogsStreamsArchivesConstant.expirationInSeconds
-        }).$promise.then(response => response.data)
-            .catch(this.ServiceHelper.errorHandler("streams_archives_url_load_error"));
+        }).$promise.then(response => response.data);
     }
 
     /**

--- a/client/app/dbaas/logs/detail/streams/archives/translations/Messages_en_GB.xml
+++ b/client/app/dbaas/logs/detail/streams/archives/translations/Messages_en_GB.xml
@@ -2,7 +2,7 @@
 <translations>
     <translation id="streams_archives_loading_error">Error loading archive: {{message}}</translation>
     <translation id="streams_archives_ids_loading_error">Error loading archive IDs: {{message}}</translation>
-    <translation id="streams_archives_url_load_error">Error loading archive url: {{message}}</translation>
+    <translation id="streams_archives_url_load_error">Error loading archive url for {{filename}}: {{message}}</translation>
     <translation id="streams_archives_download_error">Error downloading archive: {{message}}</translation>
 
     <translation id="streams_archives_unfreeze_start">Initializing unfreezing of {{filename}}</translation>

--- a/client/app/dbaas/logs/detail/streams/archives/translations/Messages_fr_FR.xml
+++ b/client/app/dbaas/logs/detail/streams/archives/translations/Messages_fr_FR.xml
@@ -2,7 +2,7 @@
 <translations>
     <translation id="streams_archives_loading_error">Erreur lors du chargement des archives: {{message}}</translation>
     <translation id="streams_archives_ids_loading_error">Erreur lors du chargement des ID d'archive: {{message}}</translation>
-    <translation id="streams_archives_url_load_error">Erreur lors du chargement de l'URL de l'archive: {{message}}</translation>
+    <translation id="streams_archives_url_load_error">Erreur lors du chargement de l'URL de l'archive pour {{filename}}: {{message}}</translation>
     <translation id="streams_archives_download_error">Erreur lors du téléchargement des archives: {{message}}</translation>
 
     <translation id="streams_archives_unfreeze_start">Initialisation du dégel de {{filename}}</translation>

--- a/client/app/helper/controller-helper.service.js
+++ b/client/app/helper/controller-helper.service.js
@@ -1,8 +1,9 @@
 class ControllerHelper {
-    constructor (ControllerModalHelper, ControllerRequestHelper, ControllerNavigationHelper) {
+    constructor ($timeout, ControllerModalHelper, ControllerRequestHelper, ControllerNavigationHelper) {
         this.request = ControllerRequestHelper;
         this.modal = ControllerModalHelper;
         this.navigation = ControllerNavigationHelper;
+        this.$timeout = $timeout;
     }
 
     downloadUrl (url) {
@@ -59,6 +60,10 @@ class ControllerHelper {
             return err;
         }
         return "";
+    }
+
+    scrollPageToTop () {
+        this.$timeout(() => scrollTo(0, 0), 100);
     }
 }
 


### PR DESCRIPTION
### Requirements

* The unsealing notification should have the count-down instead of the static time
* When the user clicks download/unfreeze, the page should scroll to the top

## Title of the Pull Requests <!-- required -->


### Description of the Change

<!-- required -->
<!-- can be an aglomeration of commits bodies -->
* All of the above requirements are handled
* The notifications handling has been cleaned up