### PR TITLE
fix(pci): lower the z-index of overlay

### DIFF
--- a/client/components/highlightedElement/highlightedElement.less
+++ b/client/components/highlightedElement/highlightedElement.less
@@ -12,7 +12,7 @@
         left: 0;
         right: 0;
         bottom: 0;
-        z-index: @SIDEBAR_MENU_Z_INDEX + 1;
+        z-index: @SIDEBAR_MENU_Z_INDEX - 1;
         background: rgba(255, 255, 255, 0.8);
     }
 


### PR DESCRIPTION
Lower the z-index of the overlay so that it is under navbar, under side
bar and under the popovers
