### PR TITLE
Changing OVH Metrics Grafana URL

### DIFF
--- a/client/app/dbaas/dbaas-metrics/metrics.constant.js
+++ b/client/app/dbaas/dbaas-metrics/metrics.constant.js
@@ -7,7 +7,7 @@ angular.module("managerApp")
             },
             {
                 name: "Grafana",
-                url: "https://grafana.tsaas.ovh.com"
+                url: "https://grafana.metrics.ovh.net"
             }
         ],
         protos: [


### PR DESCRIPTION
## Changing OVH Metrics Grafana URL

The OVH Metrics team has recently changed the URL for the public Grafana instances from `https://grafana.tsaas.ovh.com/` to `https://grafana.metrics.ovh.net`. 

The old URL will still work for some time, but it would be great to update it as soon as possible.


### Description of the Change

Changing the URL on `metrics.constants.js`

