### PR TITLE
Enable archives when cold storage is enabled

### DIFF
--- a/client/app/dbaas/logs/detail/streams/home/logs-streams-home.html
+++ b/client/app/dbaas/logs/detail/streams/home/logs-streams-home.html
@@ -27,7 +27,7 @@
         </oui-column>
         <oui-column title="::'logs_streams_col_archives' | translate" property="info.archives.length" sortable>
             <span data-ng-if="$row.info.coldStorageEnabled" data-ng-bind="$row.info.archives.length" />
-            <span data-ng-if="!$row.info.coldStorageEnabled"> - </span>
+            <span data-ng-if="!$row.info.coldStorageEnabled"> {{ $row.info.nbArchive || "-" }} </span>
         </oui-column>
         <oui-column title="::'logs_streams_col_notifications' | translate" property="info.notifications.length" sortable>
             <span data-ng-if="$row.info.notifications.length" data-ng-bind="$row.info.notifications.length" />
@@ -44,7 +44,7 @@
             <oui-action-menu-item disabled="!$row.info.isEditable" text="{{ ::'common_edit' | translate }}" on-click="ctrl.edit($row)"></oui-action-menu-item>
             <oui-action-menu-item disabled="!$row.info.canAlert" text="{{ ::'logs_streams_manage_alerts' | translate }}" on-click="ctrl.manageAlerts($row)"></oui-action-menu-item>
             <oui-action-menu-item disabled="!$row.info.webSocketEnabled" text="{{ ::'logs_streams_follow_live' | translate }}" on-click="ctrl.followLive($row)"></oui-action-menu-item>
-            <oui-action-menu-item disabled="!$row.info.coldStorageEnabled" text="{{ ::'logs_streams_archives' | translate }}" on-click="ctrl.gotoArchives($row)"></oui-action-menu-item>
+            <oui-action-menu-item disabled="!$row.info.coldStorageEnabled && $row.info.nbArchive === 0" text="{{ ::'logs_streams_archives' | translate }}" on-click="ctrl.gotoArchives($row)"></oui-action-menu-item>
         </oui-action-menu>
     </oui-datagrid>
 </section>

--- a/client/app/dbaas/logs/detail/streams/home/logs-streams-home.html
+++ b/client/app/dbaas/logs/detail/streams/home/logs-streams-home.html
@@ -39,12 +39,12 @@
         </oui-column>
         <oui-action-menu compact>
             <oui-action-menu-item text="{{ ::'logs_streams_graylog_access' | translate }}" href="{{ctrl.getGraylogUrl($row)}}" external></oui-action-menu-item>
-            <oui-action-menu-item data-ng-if="$row.info.isEditable" text="{{ ::'logs_streams_copy_token' | translate }}" on-click="ctrl.copyToken($row)"></oui-action-menu-item>
-            <oui-action-menu-item data-ng-if="$row.info.isEditable" text="{{ ::'common_delete' | translate }}" on-click="ctrl.showDeleteConfirm($row)"></oui-action-menu-item>
-            <oui-action-menu-item data-ng-if="$row.info.isEditable" text="{{ ::'common_edit' | translate }}" on-click="ctrl.edit($row)"></oui-action-menu-item>
-            <oui-action-menu-item data-ng-if="$row.info.canAlert" text="{{ ::'logs_streams_manage_alerts' | translate }}" on-click="ctrl.manageAlerts($row)"></oui-action-menu-item>
-            <oui-action-menu-item data-ng-if="$row.info.webSocketEnabled" text="{{ ::'logs_streams_follow_live' | translate }}" on-click="ctrl.followLive($row)"></oui-action-menu-item>
-            <oui-action-menu-item data-ng-if="$row.info.nbArchive > 0" text="{{ ::'logs_streams_archives' | translate }}" on-click="ctrl.gotoArchives($row)"></oui-action-menu-item>
+            <oui-action-menu-item disabled="!$row.info.isEditable" text="{{ ::'logs_streams_copy_token' | translate }}" on-click="ctrl.copyToken($row)"></oui-action-menu-item>
+            <oui-action-menu-item disabled="!$row.info.isEditable" text="{{ ::'common_delete' | translate }}" on-click="ctrl.showDeleteConfirm($row)"></oui-action-menu-item>
+            <oui-action-menu-item disabled="!$row.info.isEditable" text="{{ ::'common_edit' | translate }}" on-click="ctrl.edit($row)"></oui-action-menu-item>
+            <oui-action-menu-item disabled="!$row.info.canAlert" text="{{ ::'logs_streams_manage_alerts' | translate }}" on-click="ctrl.manageAlerts($row)"></oui-action-menu-item>
+            <oui-action-menu-item disabled="!$row.info.webSocketEnabled" text="{{ ::'logs_streams_follow_live' | translate }}" on-click="ctrl.followLive($row)"></oui-action-menu-item>
+            <oui-action-menu-item disabled="!$row.info.coldStorageEnabled" text="{{ ::'logs_streams_archives' | translate }}" on-click="ctrl.gotoArchives($row)"></oui-action-menu-item>
         </oui-action-menu>
     </oui-datagrid>
 </section>


### PR DESCRIPTION
### Requirements

* The archives menu item should be enabled when cold storage is enabled, even if the number of archives is 0

## Title of the Pull Requests <!-- required -->
Enable archives when cold storage is enabled

### Description of the Change

<!-- required -->
<!-- can be an aglomeration of commits bodies -->
* Archives is enabled if cold storage is enabled.
* All menu items in streams home page are disabled instead of hiding them

JIRA link: UML-50
