### PR TITLE
fix(me-alerts): fix bad links to billing statements

### DIFF
--- a/client/components/me-alerts/me-alerts.service.js
+++ b/client/components/me-alerts/me-alerts.service.js
@@ -24,12 +24,13 @@ class MeAlertsService {
                             if (_.get(alert, "data.debtAccount.unmaturedAmount.value", 0) > 0) {
                                 this.warningAlert(this.$translate.instant("me_alerts_DEBTACCOUNT_DEBT_WITH_UNMATURED_AMOUNT", {
                                     dueAmount: _.get(alert, "data.debtAccount.dueAmount.text"),
-                                    unmaturedAmount: _.get(alert, "data.debtAccount.unmaturedAmount.text")
+                                    unmaturedAmount: _.get(alert, "data.debtAccount.unmaturedAmount.text"),
+                                    link: this.REDIRECT_URLS.billing
                                 }));
                             } else {
                                 this.warningAlert(this.$translate.instant("me_alerts_DEBTACCOUNT_DEBT", {
                                     value: _.get(alert, "data.debtAccount.dueAmount.text"),
-                                    link: this.REDIRECT_URLS.paymentMeans
+                                    link: this.REDIRECT_URLS.billing
                                 }));
                             }
                             break;

--- a/client/components/me-alerts/translations/Messages_fr_FR.xml
+++ b/client/components/me-alerts/translations/Messages_fr_FR.xml
@@ -14,7 +14,7 @@
 
    <translation id="me_alerts_OVHACCOUNT_DEBT" qtlid="344435">Votre compte OVH est débiteur de <strong>{{value}}</strong> au {{date | date:'medium'}}. Rendez-vous dans <a href="{{link}}" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
    <translation id="me_alerts_DEBTACCOUNT_DEBT" qtlid="344448">Vous avez une dette de <strong>{{value}}</strong>. Rendez-vous dans <a href="{{link}}" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
-   <translation id="me_alerts_DEBTACCOUNT_DEBT_WITH_UNMATURED_AMOUNT" qtlid="369503">Vous avez une dette de <strong>{{ dueAmount }}</strong> (dont un montant de {{ unmaturedAmount }} non échu). Rendez-vous dans <a href="#/billing/statements" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
+   <translation id="me_alerts_DEBTACCOUNT_DEBT_WITH_UNMATURED_AMOUNT" qtlid="369503">Vous avez une dette de <strong>{{ dueAmount }}</strong> (dont un montant de {{ unmaturedAmount }} non échu). Rendez-vous dans <a href="{{ link }}" class="alert-link">la section facturation</a> pour régulariser la situation.</translation>
 
    <translation id="me_alerts_OVHACCOUNT_ALERTTHRESHOLD" qtlid="354051">Votre compte OVH a atteint le seuil que vous avez défini. Rendez-vous dans <a href="{{link}}" class="alert-link">la section facturation</a> pour plus d'informations.</translation>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud",
-  "version": "6.11.4",
+  "version": "7.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fix bad links from me-alerts that point to billing/statements section.

- [ ] change qtlid in translator
- [ ] retrieve trads