### PR TITLE
fix: cui-loader removal

### DIFF
--- a/client/app/cloud/project/openstack/users/rclone/openstack-users-rclone.modal.html
+++ b/client/app/cloud/project/openstack/users/rclone/openstack-users-rclone.modal.html
@@ -2,7 +2,7 @@
     <form novalidate name="$ctrl.form">
         <cui-modal-header data-on-dismiss="$ctrl.cancel()"></cui-modal-header>
         <cui-modal-body data-title=":: 'cpou_rclone_modal_title' | translate">
-            <cui-loader data-ng-if="$ctrl.isModalLoading()"></cui-loader>
+            <oui-spinner data-ng-if="$ctrl.isModalLoading()"></oui-spinner>
             <div data-ng-if="!$ctrl.isModalLoading()">
                 <cui-modal-text>
                     <span data-translate="cpou_rclone_modal_explanation"></span>


### PR DESCRIPTION
**SCDC-771**
### Requirements

* The cui-loader component has to be replaced by oui-spinner from ovh-ui-angular

## Replace cui-loader with oui-spinner


### Description of the Change

The cui-loader component has been replaced with oui-spinner from ovh-ui-angular

### Benefits

The component from the library is re-used, giving a more uniform look across Manager