### PR TITLE
fix(iplb): remove unused call to /ipLoadbalancing/availableZones

### DIFF
--- a/client/app/iplb/iplb-zone.service.js
+++ b/client/app/iplb/iplb-zone.service.js
@@ -1,6 +1,5 @@
 class IpLoadBalancerZoneService {
-    constructor ($q, $translate, OvhApiIpLoadBalancing, RegionService) {
-        this.$q = $q;
+    constructor ($translate, OvhApiIpLoadBalancing, RegionService) {
         this.$translate = $translate;
         this.IpLoadBalancing = OvhApiIpLoadBalancing;
         this.RegionService = RegionService;
@@ -16,29 +15,17 @@ class IpLoadBalancerZoneService {
             })));
     }
 
-    getZones () {
-        return this.IpLoadBalancing.v6().availableZones().$promise
-            .then(zones => zones.filter(zone => !/private$/.test(zone))
-                .filter(zone => !/^all/.test(zone))
-                .map(zone => ({
-                    id: zone,
-                    name: this.RegionService.getRegion(zone).microRegion.text
-                })));
-    }
-
     getZonesSelectData (serviceName) {
-        return this.$q.all({
-            allZones: this.getZones(),
-            iplbZones: this.getIPLBZones(serviceName)
-        }).then(({ allZones, iplbZones }) => {
-            if (iplbZones.length >= allZones.length || true) {
+        return this
+            .getIPLBZones(serviceName)
+            .then((iplbZones) => {
                 iplbZones.push({
                     id: "all",
                     name: this.$translate.instant("iplb_zone_all")
                 });
-            }
-            return iplbZones;
-        });
+
+                return iplbZones;
+            });
     }
 
     humanizeZone (zone) {


### PR DESCRIPTION
## fix(iplb): remove unused call to /ipLoadbalancing/availableZones

### Description of the Change

APIv6 call https://api.ovh.com/console/#/ipLoadbalancing/availableZones#GET
is now deprecated and will be removed soon.

It was loaded within the iplb manager but not used. I removed it.

### Benefits

Removed 1 uneeded call

Internal reference: SCFRCA-1417