### PR TITLE
Hotfix/add instance name in Deleting dialog

### DIFF
--- a/client/app/cloud/project/compute/infrastructure/cloud-project-compute-infrastructure.service.js
+++ b/client/app/cloud/project/compute/infrastructure/cloud-project-compute-infrastructure.service.js
@@ -123,7 +123,7 @@ class CloudProjectComputeInfrastructureService {
             controller: "CloudprojectcomputeinfrastructurevirtualmachinedeleteCtrl",
             controllerAs: "$ctrl",
             resolve: {
-                params: () => vm
+                params: () => ({ vm })
             }
         }).result.then(() => this.CloudProjectComputeInfrastructureOrchestrator.deleteVm(vm)
             .catch(this.ServiceHelper.errorHandler("cpci_vm_delete_submit_error"))

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.controller.js
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.controller.js
@@ -26,25 +26,6 @@ angular.module("managerApp")
         function init () {
             self.isMonthlyBilling = vmToDelete.monthlyBilling && vmToDelete.monthlyBilling.status === "ok";
 
-            /*
-             * IP Failover are not automatically deleted so we comment the check below.
-             */
-            // check if the instance is routed to failover IPs
-            /*self.loaders.ips = true;
-            OvhApiCloudProjectIpFailover.v6().query({
-                serviceName : serviceName
-            }).$promise.then(function (ips) {
-                if (vmToDelete && vmToDelete.routedTo) {
-                    angular.forEach(vmToDelete.routedTo, function (route) {
-                        var ipfo = _.find(ips, { id : route });
-                        if (ipfo) {
-                            self.routedIpsFo.push(ipfo);
-                        }
-                    });
-                }
-            })["finally"](function () {
-                self.loaders.ips = false;
-            });*/
         }
 
 

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.controller.js
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.controller.js
@@ -1,14 +1,12 @@
 "use strict";
 
 angular.module("managerApp")
-  .controller("CloudprojectcomputeinfrastructurevirtualmachinedeleteCtrl", function ($uibModalInstance, $stateParams, params, OvhApiCloudProjectIpFailover) {
-        var self = this,
-            serviceName = $stateParams.projectId;
-
-        var vmToDelete = params;
+    .controller("CloudprojectcomputeinfrastructurevirtualmachinedeleteCtrl", function ($uibModalInstance, params) {
+        const self = this;
+        self.vm = params.vm;
 
         self.loaders = {
-            ips : false
+            ips: false
         };
 
         self.routedIpsFo = [];
@@ -24,10 +22,9 @@ angular.module("managerApp")
         };
 
         function init () {
-            self.isMonthlyBilling = vmToDelete.monthlyBilling && vmToDelete.monthlyBilling.status === "ok";
-
+            self.isMonthlyBilling = _(self.vm).get("monthlyBilling.status") === "ok";
         }
 
 
         init();
-  });
+    });

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.html
@@ -20,10 +20,10 @@
                     <li class="red" data-ng-repeat="ip in CloudprojectcomputeinfrastructurevirtualmachinedeleteCtrl.routedIpsFo track by ip.id">{{ ip.ip }}</li>
                 </ul>
             </div>
-            <p class="oui-modal__text">
-                <strong
-                    data-translate="cpcivm_delete_confirm"
-                    data-translate-values="{ instanceName: $ctrl.vm.name }"></strong>
+            <p
+                class="oui-modal__text font-weight-bold"
+                data-translate="cpcivm_delete_confirm"
+                data-translate-values="{ instanceName: $ctrl.vm.name }">
             </p>
         </div>
     </div>

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/cloud-project-compute-infrastructure-virtual-machine-delete.html
@@ -20,7 +20,11 @@
                     <li class="red" data-ng-repeat="ip in CloudprojectcomputeinfrastructurevirtualmachinedeleteCtrl.routedIpsFo track by ip.id">{{ ip.ip }}</li>
                 </ul>
             </div>
-            <p class="oui-modal__text"><strong data-translate="cpcivm_delete_confirm"></strong></p>
+            <p class="oui-modal__text">
+                <strong
+                    data-translate="cpcivm_delete_confirm"
+                    data-translate-values="{ instanceName: $ctrl.vm.name }"></strong>
+            </p>
         </div>
     </div>
 

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/translations/Messages_fr_FR.xml
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/delete/translations/Messages_fr_FR.xml
@@ -3,5 +3,5 @@
    <translation id="cpcivm_delete_title" qtlid="247950">Suppression d'une instance</translation>
    <translation id="cpcivm_delete_info" qtlid="247963">Le forfait du mois en cours pour ce serveur a déjà été facturé, il sera perdu.</translation>
    <translation id="cpcivm_failover_info" qtlid="269383">Les IPs Failover suivantes seront supprimées définitivement :</translation>
-   <translation id="cpcivm_delete_confirm" qtlid="269396">Êtes vous sûr de vouloir supprimer cette instance ?</translation>
+   <translation id="cpcivm_delete_confirm">Êtes vous sûr de vouloir supprimer l'instance {{instanceName}} ?</translation>
 </translations>


### PR DESCRIPTION
## Add instance name in Deleting dialog

Internal reference: SCFRCA-922

### Description of the Change

Before: no indication of the deleted instance in the dialog
Now: the user can't get mixed up in the instance he or she is trying to delete