### PR TITLE
Replace cui-tile with oui-tile in Cloud Manager Home

### DIFF
--- a/client/app/home/home.html
+++ b/client/app/home/home.html
@@ -17,7 +17,7 @@
                             data-at-internet-click="{ name: link.atInternetClickTag }"
                             data-ng-href="{{ link.href }}"
                             ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}"
-                            ng-attr="{'rel=noopener': link.isExternal}">
+                            ng-attr-rel="{{(link.isExternal) ? 'noopener' : undefined}}">
                             <span data-ng-bind="link.text"></span>
                             <span class="oui-icon oui-icon-external_link" data-ng-if="link.isExternal" aria-hidden="true"></span>
                         </a>

--- a/client/app/home/home.html
+++ b/client/app/home/home.html
@@ -10,20 +10,20 @@
     </div>
     <div class="row d-md-flex">
         <div class="col-md-10 col-lg-8 mx-md-auto">
-            <cui-tile data-ng-repeat="section in $ctrl.guides.sections track by $index"
-                      data-title="section.title | translate"
-                      class="cui-tile mb-5">
-                <div class="cui-tile__top-bordered"
-                     data-ng-repeat="link in section.list track by $index">
-                    <a class="oui-button oui-button_link oui-button_full-width cui-tile__button"
-                       data-at-internet-click="{ name: link.atInternetClickTag }"
-                       data-ng-href="{{ link.href }}"
-                       ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}">
-                        <span data-ng-bind="link.text"></span>
-                        <span class="oui-icon oui-icon-external_link" data-ng-if="link.isExternal" aria-hidden="true"></span>
-                    </a>
-                </div>
-            </cui-tile>
+            <div class="mb-5" data-ng-repeat="section in $ctrl.guides.sections track by $index">
+                <oui-tile data-heading="{{section.title | translate}}">
+                    <div class="oui-tile__item oui-tile__item_button" data-ng-repeat="link in section.list track by $index">
+                        <a class="oui-tile__button oui-button oui-link_icon oui-button_link oui-button_full-width"
+                            data-at-internet-click="{ name: link.atInternetClickTag }"
+                            data-ng-href="{{ link.href }}"
+                            ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}"
+                            ng-attr="{'rel=noopener': link.isExternal}">
+                            <span data-ng-bind="link.text"></span>
+                            <span class="oui-icon oui-icon-external_link" data-ng-if="link.isExternal" aria-hidden="true"></span>
+                        </a>
+                    </div>
+                </oui-tile>
+            </div>
         </div>
     </div>
 </div>

--- a/client/app/home/home.html
+++ b/client/app/home/home.html
@@ -14,12 +14,12 @@
                 <oui-tile data-heading="{{::section.title | translate}}">
                     <div class="oui-tile__item oui-tile__item_button" data-ng-repeat="link in section.list track by $index">
                         <a class="oui-tile__button oui-button oui-link_icon oui-button_link oui-button_full-width"
-                            data-at-internet-click="{ name: link.atInternetClickTag }"
-                            data-ng-href="{{ link.href }}"
-                            data-ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}"
-                            data-ng-attr-rel="{{(link.isExternal) ? 'noopener' : undefined}}">
-                            <span data-ng-bind="link.text"></span>
-                            <span class="oui-icon oui-icon-external_link" data-ng-if="link.isExternal" aria-hidden="true"></span>
+                           data-at-internet-click="{ name: link.atInternetClickTag }"
+                           data-ng-href="{{ link.href }}"
+                           data-ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}"
+                           data-ng-attr-rel="{{(link.isExternal) ? 'noopener' : undefined}}">
+                           <span data-ng-bind="link.text"></span>
+                           <span class="oui-icon oui-icon-external_link" data-ng-if="link.isExternal" aria-hidden="true"></span>
                         </a>
                     </div>
                 </oui-tile>

--- a/client/app/home/home.html
+++ b/client/app/home/home.html
@@ -14,6 +14,7 @@
                 <oui-tile data-heading="{{::section.title | translate}}">
                     <div class="oui-tile__item oui-tile__item_button" data-ng-repeat="link in section.list track by $index">
                         <a class="oui-tile__button oui-button oui-link_icon oui-button_link oui-button_full-width"
+                           title="{{ (link.isExternal) ? link.text + ' (' + ('common_new_window' | translate) + ')' : link.text }}"
                            data-at-internet-click="{ name: link.atInternetClickTag }"
                            data-ng-href="{{ link.href }}"
                            data-ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}"

--- a/client/app/home/home.html
+++ b/client/app/home/home.html
@@ -11,13 +11,13 @@
     <div class="row d-md-flex">
         <div class="col-md-10 col-lg-8 mx-md-auto">
             <div class="mb-5" data-ng-repeat="section in $ctrl.guides.sections track by $index">
-                <oui-tile data-heading="{{section.title | translate}}">
+                <oui-tile data-heading="{{::section.title | translate}}">
                     <div class="oui-tile__item oui-tile__item_button" data-ng-repeat="link in section.list track by $index">
                         <a class="oui-tile__button oui-button oui-link_icon oui-button_link oui-button_full-width"
                             data-at-internet-click="{ name: link.atInternetClickTag }"
                             data-ng-href="{{ link.href }}"
-                            ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}"
-                            ng-attr-rel="{{(link.isExternal) ? 'noopener' : undefined}}">
+                            data-ng-attr-target="{{(link.isExternal) ? '_blank' : undefined}}"
+                            data-ng-attr-rel="{{(link.isExternal) ? 'noopener' : undefined}}">
                             <span data-ng-bind="link.text"></span>
                             <span class="oui-icon oui-icon-external_link" data-ng-if="link.isExternal" aria-hidden="true"></span>
                         </a>


### PR DESCRIPTION
SCDC-859

### Requirements

* Then cui-tile component has to be replaced with oui-tile from ovh-ui-angular, in Cloud Manager Home

## Replace cui-tile with oui-tile in Cloud Manager Home

### Description of the Change

The cui-tile component has been replaced by oui-tile from ovh-ui-angular, in Cloud Manager Home

### Benefits

The component from the library is re-used, giving a more uniform look across Manager