### PR TITLE
Replace cui-dropdown-menu with oui-dropdown

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -79,7 +79,7 @@ angular.module("managerApp", [
             table: "oui-table oui-table_responsive",
             thead: "oui-table__headers",
             tbody: "oui-table__body",
-            tr: "oui-table__row cui-dropdown-menu-container",
+            tr: "oui-table__row",
             th: "oui-table__header",
             td: "oui-table__cell",
             sortable: "oui-table__cell_sortable oui-table__cell_sortable-asc",

--- a/client/app/dbaas/dbaas-metrics/token/metrics-token.controller.js
+++ b/client/app/dbaas/dbaas-metrics/token/metrics-token.controller.js
@@ -45,18 +45,18 @@
                 <span class="token-labels" data-ng-repeat="label in $row.labels | orderBy : 'key'" data-ng-if="$index < 2">
                     <span data-ng-bind="label.key"></span>:<span data-ng-bind="label.value"></span>
                 </span>
-                <cui-dropdown-menu data-ng-if="$row.labels.length > 2">
-                    <cui-dropdown-menu-button>
-                        <div class="token-labels__button-container">
-                            <span class="token-labels token-labels__button" data-ng-bind="MetricsTokenCtrl.displayRemainingLabels($row.labels.length - 2)"></span>
+                <oui-dropdown data-ng-if="$row.labels.length > 2" data-arrow data-align="end">
+                    <div data-oui-dropdown-trigger>
+                        <span class="token-labels token-labels__button" data-ng-bind="MetricsTokenCtrl.displayRemainingLabels($row.labels.length - 2)"></span>
+                    </div>
+                    <oui-dropdown-content>
+                        <div class="token-labels-container">
+                            <span class="token-labels" data-ng-repeat="label in $row.labels | orderBy : 'key' track by $index" data-ng-if="$index >= 2">
+                                <span data-ng-bind="label.key"></span>:<span data-ng-bind="label.value"></span>
+                            </span>
                         </div>
-                    </cui-dropdown-menu-button>
-                    <cui-dropdown-menu-body class="token-labels-container">
-                        <span class="token-labels" data-ng-repeat="label in $row.labels | orderBy : 'key'" data-ng-if="$index >= 2">
-                            <span data-ng-bind="label.key"></span>:<span data-ng-bind="label.value"></span>
-                        </span>
-                    </cui-dropdown-menu-body>
-                </cui-dropdown-menu>
+                    </oui-dropdown-content>
+                </oui-dropdown>
             `;
         }
 

--- a/client/app/iplb/configuration/iplb-configuration.controller.js
+++ b/client/app/iplb/configuration/iplb-configuration.controller.js
@@ -85,22 +85,12 @@ class IpLoadBalancerConfigurationCtrl {
 
     actionTemplate () {
         return `
-            <cui-dropdown-menu>
-                <cui-dropdown-menu-button>
-                    <ng-include src="'app/ui-components/icons/button-action.html'"></ng-include>
-                </cui-dropdown-menu-button>
-                <cui-dropdown-menu-body>
-                    <div class="oui-action-menu">
-                        <div class="oui-action-menu__item oui-action-menu-item">
-                            <div class="oui-action-menu-item__icon"></div>
-                            <button class="oui-button oui-button_link oui-action-menu-item__label"
-                                type="button"
-                                data-ng-bind="'iplb_configuration_action_apply' | translate"
-                                data-ng-click="ctrl.applyChanges($row.id)"></button>
-                        </div>
-                    </div>
-                </cui-dropdown-menu-body>
-            </cui-dropdown-menu>`;
+            <oui-action-menu data-align="end" data-compact>
+                <oui-action-menu-item
+                    data-text="{{'iplb_configuration_action_apply' | translate}}"
+                    data-on-click="ctrl.applyChanges($row.id)">
+                </oui-action-menu-item>
+            </oui-action-menu>`;
     }
 }
 

--- a/client/app/iplb/sslCertificate/iplb-ssl-certificate.controller.js
+++ b/client/app/iplb/sslCertificate/iplb-ssl-certificate.controller.js
@@ -48,38 +48,21 @@ class IpLoadBalancerSslCertificateCtrl {
 
     actionTemplate () {
         return `
-            <cui-dropdown-menu>
-                <cui-dropdown-menu-button>
-                    <ng-include src="'app/ui-components/icons/button-action.html'"></ng-include>
-                </cui-dropdown-menu-button>
-                <cui-dropdown-menu-body>
-                    <div class="oui-action-menu">
-                        <div class="oui-action-menu__item oui-action-menu-item">
-                            <div class="oui-action-menu-item__icon"></div>
-                            <button class="oui-button oui-button_link oui-action-menu-item__label"
-                                type="button"
-                                data-ng-bind="'iplb_ssl_see' | translate"
-                                data-ng-click="ctrl.preview($row)"></button>
-                        </div>
-                    </div>
-                    <div class="oui-action-menu">
-                        <div class="oui-action-menu__item oui-action-menu-item">
-                            <div class="oui-action-menu-item__icon"></div>
-                            <button class="oui-button oui-button_link oui-action-menu-item__label"
-                                type="button"
-                                data-ng-bind="'iplb_ssl_update' | translate"
-                                data-ng-click="ctrl.update($row)"></button>
-                        </div>
-                        <div class="oui-action-menu__item oui-action-menu-item">
-                            <div class="oui-action-menu-item__icon"></div>
-                            <button class="oui-button oui-button_link oui-action-menu-item__label"
-                                type="button"
-                                data-ng-bind="'iplb_ssl_delete' | translate"
-                                data-ng-click="ctrl.delete($row)"></button>
-                        </div>
-                    </div>
-                </cui-dropdown-menu-body>
-            </cui-dropdown-menu>`;
+            <oui-action-menu data-align="end" data-compact>
+                <oui-action-menu-item
+                    data-text="{{'iplb_ssl_see' | translate}}"
+                    data-on-click="ctrl.preview($row)">
+                </oui-action-menu-item>
+                <oui-action-menu-divider></oui-action-menu-divider>
+                <oui-action-menu-item
+                    data-text="{{'iplb_ssl_update' | translate}}"
+                    data-on-click="ctrl.update($row)">
+                </oui-action-menu-item>
+                <oui-action-menu-item
+                    data-text="{{'iplb_ssl_delete' | translate}}"
+                    data-on-click="ctrl.delete($row)">
+                </oui-action-menu-item>
+            </oui-action-menu>`;
     }
 }
 

--- a/client/app/oui-less-override.less
+++ b/client/app/oui-less-override.less
@@ -27,10 +27,6 @@
 
         .tablet({
             width: 100%;
-
-            .cui-dropdown-menu {
-                float: right;
-            }
         });
     }
 

--- a/client/app/ui-components/accordion/accordion.component.js
+++ b/client/app/ui-components/accordion/accordion.component.js
@@ -10,7 +10,7 @@ angular.module("managerApp")
         template: `
             <div class="cui-accordion cui-accordion-list__item"
                 data-ng-class="{ 'cui-accordion_open': $ctrl.expanded }">
-                <div class="cui-accordion__header cui-dropdown-menu-container">
+                <div class="cui-accordion__header">
                     <div class="cui-accordion__header-text">
                         <h5 role="button" tabindex="0"
                             class="oui-header_5 cui-accordion__header-title"


### PR DESCRIPTION
SCDC-819

### Requirements

* The cui-dropdown-menu has to be replaced with oui-dropdown from ovh-ui-angular

## Replace cui-dropdown-menu with oui-dropdown

### Description of the Change

The cui-dropdown-menu component has been replaced by oui-dropdown from ovh-ui-angular

### Benefits

The component from the library is re-used, giving a more uniform look across Manager