### PR TITLE
chore(deps): bump ovh-ui-kit and ovh-ui-angular

### DIFF
--- a/client/app/app.tpl.less
+++ b/client/app/app.tpl.less
@@ -102,10 +102,6 @@ html {
   height: 100%;
 }
 /* Move down content because we have a fixed navbar that is 50px tall */
-body {
-  .font-open-sans;
-  font-size : @DefaultFontSize;
-}
 @media (min-width: @v6-min-with) {
     body {
         margin-top : @TopNavHeight;

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
     "@bower_components/uri.js": "medialize/URI.js#~1.15.0",
     "@bower_components/validator-js": "chriso/validator.js#~3.37.0",
     "xterm": "^3.4.1",
-    "ovh-ui-angular": "~2.16.4",
-    "ovh-ui-kit": "~2.16.3",
+    "ovh-ui-angular": "~2.17.1",
+    "ovh-ui-kit": "~2.17.1",
     "popper.js": "^1.14.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6261,18 +6261,18 @@ ovh-protractor-jasmine2-logs-reporter@~0.0.1:
   dependencies:
     q "^1.4.1"
 
-ovh-ui-angular@~2.16.0:
-  version "2.16.4"
-  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-2.16.4.tgz#9d58afc801f6ae15f9142d75a0d65011036c8c2a"
+ovh-ui-angular@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-2.17.1.tgz#ed86530038bcbc60bb9d0a03d00e33327439fe48"
   dependencies:
     clipboard "2.0.1"
     escape-string-regexp "^1.0.5"
     flatpickr "4.5.0"
     popper.js "^1.14.3"
 
-ovh-ui-kit@~2.16.0:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.16.3.tgz#4a94f52f291a49d7186091826fbd95210ebfe38c"
+ovh-ui-kit@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.17.1.tgz#74cc15ee84e495206c415a14f4f47ebd50c1bb23"
   dependencies:
     less-plugin-remcalc "^0.0.1"
 
@@ -8456,6 +8456,10 @@ xmlhttprequest-ssl@1.5.3:
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xterm@^3.4.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.5.1.tgz#d2e62ab26108a771b7bd1b7be4f6578fb4aff922"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Bump `ovh-ui-kit` and `ovh-ui-angular`

### Description of the Change

4eeb4e5 — chore(deps): bump ovh-ui-kit and ovh-ui-angular

bump:
- ovh-ui-kit from `v2.16.x` to `v2.17.x`
- ovh-ui-angular from `v2.16.x` to `v2.17.x`

/cc @jleveugle @Jisay @frenautvh @cbourgois 