### PR TITLE
fix(vps): retrieve right price of snapshot option

### DIFF
--- a/client/app/vps/import/vps.service.js
+++ b/client/app/vps/import/vps.service.js
@@ -688,7 +688,7 @@ angular.module("managerApp").service("VpsService", [
         };
 
         this.getOptionSnapshotFormated = function (serviceName, vps) {
-            if (vps.version === "_2015_V_1" && vps.offerType === "SSD") {
+            if (_.includes(["_2015_V_1", "_2018_V_1"], vps.version) && vps.offerType === "SSD") {
                 return this.getOptionSnapshot(vps)
                     .then(d => this.getOptionDetails2("snapshot", vps, d.data[0]))
                     .then(data => {


### PR DESCRIPTION
## Fix to retrieve right price of snapshot option

### Description of the Change

Fix to retrieve right price of snapshot option, adding VPS version 2018v1 in the if statement

### Benefits

Manager will show the right price for snapshot option of VPS SSD 2018v1

### Possible Drawbacks
None

### Applicable Issues
None

ref: SCFRCA-2116