### PR TITLE
chore(deps): bump ovh-angular-otrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,10 +90,10 @@
     "@bower_components/ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "@bower_components/uri.js": "medialize/URI.js#~1.15.0",
     "@bower_components/validator-js": "chriso/validator.js#~3.37.0",
-    "xterm": "^3.4.1",
     "ovh-ui-angular": "~2.17.1",
     "ovh-ui-kit": "~2.17.1",
-    "popper.js": "^1.14.1"
+    "popper.js": "^1.14.1",
+    "xterm": "^3.4.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,8 +258,8 @@
     less-plugin-remcalc "^0.0.1"
 
 "@bower_components/ovh-angular-otrs@ovh-ux/ovh-angular-otrs#^6.1.1":
-  version "6.1.1"
-  resolved "https://codeload.github.com/ovh-ux/ovh-angular-otrs/tar.gz/8a49021ab3ec36e0a7f5ecc288bbbc0cc5c10da9"
+  version "6.1.3"
+  resolved "https://codeload.github.com/ovh-ux/ovh-angular-otrs/tar.gz/41940a11121a6686c2c70e1ecce29de90b34bc9c"
 
 "@bower_components/ovh-angular-pagination-front@ovh-ux/ovh-angular-pagination-front#^5.1.0":
   version "5.0.0"


### PR DESCRIPTION
## Bump ovh-angular-otrs to `v6.1.3`

### Description of the Change

4e0a49c - chore(deps): bump ovh-angular-otrs

bump:
- ovh-angular-otrs `v6.1.1` to `v6.1.3`

/cc @lizardK @jleveugle @Jisay @frenautvh @cbourgois 