### PR TITLE
Handle new explicit flag: isShareable for role permissions

### DIFF
--- a/client/app/dbaas/logs/detail/roles/edit-permissions/edit-permissions.controller.js
+++ b/client/app/dbaas/logs/detail/roles/edit-permissions/edit-permissions.controller.js
@@ -38,7 +38,7 @@ class LogsRolesPermissionsCtrl {
         this.allAliases = this.ControllerHelper.request.getArrayLoader({
             loaderFunction: () => this.LogsRolesService.getAllAliases(this.serviceName)
                 .then(result => {
-                    const diff = _.map(_.filter(result, alias => alias.info.isEditable && !_.find(permissionList, permission => permission.aliasId === alias.info.aliasId)), "info");
+                    const diff = _.map(_.filter(result, alias => alias.info.isShareable && !_.find(permissionList, permission => permission.aliasId === alias.info.aliasId)), "info");
                     this.availableAliases.resolve(diff);
                 })
         });
@@ -49,7 +49,7 @@ class LogsRolesPermissionsCtrl {
         this.allIndices = this.ControllerHelper.request.getArrayLoader({
             loaderFunction: () => this.LogsRolesService.getAllIndices(this.serviceName)
                 .then(result => {
-                    const diff = _.map(_.filter(result, index => index.info.isEditable && !_.find(permissionList, permission => permission.indexId === index.info.indexId)), "info");
+                    const diff = _.map(_.filter(result, index => index.info.isShareable && !_.find(permissionList, permission => permission.indexId === index.info.indexId)), "info");
                     this.availableIndices.resolve(diff);
                 })
         });
@@ -60,7 +60,7 @@ class LogsRolesPermissionsCtrl {
         this.allDashboards = this.ControllerHelper.request.getArrayLoader({
             loaderFunction: () => this.LogsRolesService.getAllDashboards(this.serviceName)
                 .then(result => {
-                    const diff = _.map(_.filter(result, dashboard => dashboard.info.isEditable && !_.find(permissionList, permission => permission.dashboardId === dashboard.info.dashboardId)), "info");
+                    const diff = _.map(_.filter(result, dashboard => dashboard.info.isShareable && !_.find(permissionList, permission => permission.dashboardId === dashboard.info.dashboardId)), "info");
                     this.availableDashboards.resolve(diff);
                 })
         });
@@ -71,7 +71,7 @@ class LogsRolesPermissionsCtrl {
         this.allStreams = this.ControllerHelper.request.getArrayLoader({
             loaderFunction: () => this.LogsRolesService.getAllStreams(this.serviceName)
                 .then(result => {
-                    const diff = _.map(_.filter(result, stream => !_.find(permissionList, permission => permission.streamId === stream.info.streamId)), "info");
+                    const diff = _.map(_.filter(result, stream => stream.info.isShareable && !_.find(permissionList, permission => permission.streamId === stream.info.streamId)), "info");
                     this.availableStreams.resolve(diff);
                 })
         });


### PR DESCRIPTION
Signed-off-by: Pierre De Paepe <pierre.de-paepe@corp.ovh.com>

### Description of the Change

Since the new feature: Kibana as a service, we have to distinct index managed by LDP for kibana settings (no more editable) and index created by users that can remains safely removable by them.
As role permissions view actually relies on **isEditable** flag, it was no more possible to share a kibana instance access.
The API introduced a new flag to handle this use case: **isShareable** on dashboard, stream, index and alias objects.
This PR simply update the related view to take this flag in account.