### PR TITLE
docs(contributing): referring to the correct eslint config url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ pay attention to a few things:
 
 # Coding and documentation Style
 
-Refer to [https://github.com/ovh-ux/eslint-config-ovh](https://github.com/ovh-ux/eslint-config-ovh)
+Refer to [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base)
 
 # Submitting Modifications
 


### PR DESCRIPTION
## docs(contributing): referring to the correct eslint config url

### Description of the Change

2cbfa02 — docs(contributing): referring to the correct eslint config url

/cc @jleveugle @frenautvh @cbourgois 