### PR TITLE
fix(scripts.clean): add missing rimraf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "run-p lint:css lint:js",
     "lint:css": "stylelint 'client/**/*.less' --fix",
     "lint:js": "eslint --quiet --fix ./client",
-    "clean": "npx .cache-loader rimraf dist node_modules",
+    "clean": "npx rimraf .cache-loader rimraf dist node_modules",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
     "postversion": "git push && git push --tags"
   },


### PR DESCRIPTION
## Add missing `rimraf` dependency

### Description of the Change

d96e190 — fix(scripts.clean): add missing rimraf dependency

/cc @jleveugle @frenautvh @cbourgois 