### PR TITLE
fix(ssh-creation): button missing in windows tab

### DIFF
--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.controller.js
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.controller.js
@@ -136,6 +136,12 @@ class CloudProjectComputeInfrastructureVirtualMachineAddCtrl {
       });
   }
 
+  onSelectChange() {
+    if (this.model.imageType.type === 'windows') {
+      this.addingSshKey = false;
+    }
+  }
+
   isStep1Valid() {
     return this.model.imageType && !this.addingSshKey && (this.model.imageType.type !== 'linux' || this.model.sshKey);
   }

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
@@ -24,7 +24,8 @@
                                                data-placeholder="{{ 'cpcivm_add_step1_distribution_choose' | translate }}"
                                                data-picture="assets/images/cloud/os/{{ distribution }}_50.png"
                                                data-text="{{:: 'cpcivm_add_distribution_' + distribution | translate }}{{ imageType === 'windows' ? ' *' : '' }}"
-                                               data-values="images">
+                                               data-values="images"
+                                               data-on-change="$ctrl.onSelectChange()">
                             </oui-select-picker>
                         </div>
                     </div>


### PR DESCRIPTION
## Go to next button missing in windows tab


### Description of the Change

add event on selection of windows
set add ssh key boolean to false


### Benefits

SSH option disappears on selection of windows distribution
brings back Next button

### Possible Drawbacks

None

### Applicable Issues

MANAGER-1328