### PR TITLE
fix(openstack): route fix

### DIFF
--- a/client/app/cloud/project/openstack/openstack.controller.js
+++ b/client/app/cloud/project/openstack/openstack.controller.js
@@ -9,7 +9,6 @@
     }
 
     $onInit() {
-      this.$state.go('iaas.pci-project.compute.openstack.users');
       this.loadMessages();
     }
 

--- a/client/app/cloud/project/openstack/openstack.js
+++ b/client/app/cloud/project/openstack/openstack.js
@@ -12,6 +12,7 @@ angular.module('managerApp')
             controllerAs: 'CloudProjectOpenstackCtrl',
           },
         },
+        redirectTo: 'iaas.pci-project.compute.openstack.users',
         translations: ['.'],
       });
   });


### PR DESCRIPTION
MANAGER-1447

### Requirements

Clicking on OpenStack Tab takes the user to the openstack route instead of openstack/users route. This results in a blank space. This has to be fixed.

## Openstack route fix

### Description of the Change

The route redirection in the $onInit does not fire when clicking on the OpenStack Tab the second time. Hence this redirection has been moved to the states declaration.