### PR TITLE
fix(deps): upgrade ovh-angular-otrs to v6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ovh-angular-jquery-ui-droppable": "ovh-ux/ovh-angular-jquery-ui-droppable#^0.1.1",
     "ovh-angular-jsplumb": "ovh-ux/ovh-angular-jsplumb#^3.0.5",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
-    "ovh-angular-otrs": "ovh-ux/ovh-angular-otrs#^6.1.1",
+    "ovh-angular-otrs": "^6.3.0",
     "ovh-angular-pagination-front": "ovh-ux/ovh-angular-pagination-front#^5.1.0",
     "ovh-angular-proxy-request": "ovh-ux/ovh-angular-proxy-request#^0.1.0",
     "ovh-angular-q-allsettled": "ovh-ux/ovh-angular-q-allSettled#^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7641,9 +7641,10 @@ ovh-angular-list-view@ovh-ux/ovh-angular-list-view#^0.1.5:
     angular-mock "^1.0.0"
     less-plugin-remcalc "^0.0.1"
 
-ovh-angular-otrs@ovh-ux/ovh-angular-otrs#^6.1.1:
-  version "6.2.2"
-  resolved "https://codeload.github.com/ovh-ux/ovh-angular-otrs/tar.gz/6cb32d42b6c132b22ff6ba58b2d8ed58c9c8aa54"
+ovh-angular-otrs@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ovh-angular-otrs/-/ovh-angular-otrs-6.3.0.tgz#3ad3c9626be1917b5f0f557375de3757ad9b08ba"
+  integrity sha512-sXxQUlsC0ucl9UVcnSB9ZQsqTnKmW/zQZM+VH0gNpnJo9v3Klk4lHN3n0Wnd62Ic8Ke3Vjgk74Jk2THjQOHfcg==
 
 ovh-angular-pagination-front@ovh-ux/ovh-angular-pagination-front#^5.1.0:
   version "5.0.0"


### PR DESCRIPTION
## ⬆️ upgrade `ovh-angular-otrs` to `v6.3.0`

### Description of the Change

aff3a43 — fix(deps): upgrade ovh-angular-otrs to v6.3.0

/cc @jleveugle @frenautvh @cbourgois 