### PR TITLE
fix(load-balancer): ssl certificate load

### DIFF
--- a/client/app/iplb/frontends/iplb-frontends-edit.controller.js
+++ b/client/app/iplb/frontends/iplb-frontends-edit.controller.js
@@ -150,6 +150,7 @@ class IpLoadBalancerFrontendsEditCtrl {
     if (this.$stateParams.frontendId) {
       this.edition = true;
       this.apiFrontend.load()
+        .then(() => (this.frontend.ssl ? this.certificates.load() : null))
         .then(() => {
           this.farms.load();
         });


### PR DESCRIPTION
Close MBP-48

### Requirements

The ssl certificates are not loaded when the front-end protocol is https. This is to be fixed

## SSL Certificates load

### Description of the Change

This issue has been fixed by loading the certificates if the protocol is ssl, on the page init.