### PR TITLE
feat(openstack): openRC v3 file download

### DIFF
--- a/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.constant.js
+++ b/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.constant.js
@@ -1,0 +1,5 @@
+angular.module('managerApp')
+  .constant('CLOUD_OPENRC_VERSION', {
+    V2: 'v2.0',
+    V3: 'v3',
+  });

--- a/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.controller.js
+++ b/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.controller.js
@@ -1,7 +1,7 @@
 angular.module('managerApp')
-  .controller('OpenstackUsersOpenrcCtrl', function OpenstackUsersOpenrcCtrl($scope, OvhApiCloud,
-    $httpParamSerializer, $uibModalInstance, CONFIG_API, openstackUser, $stateParams, $translate,
-    URLS, OvhApiMe, RegionService) {
+  .controller('OpenstackUsersOpenrcCtrl', function OpenstackUsersOpenrcCtrl($httpParamSerializer,
+    $stateParams, $uibModalInstance, CLOUD_OPENRC_VERSION, CONFIG_API, openstackUser,
+    OvhApiCloud, OvhApiMe, RegionService, URLS) {
     const self = this;
 
     self.regionService = RegionService;
@@ -15,6 +15,7 @@ angular.module('managerApp')
     self.data = {
       region: null,
       guideURL: null,
+      v3: false,
     };
 
     self.loaders = {
@@ -59,6 +60,7 @@ angular.module('managerApp')
         '?',
         $httpParamSerializer({
           region: self.data.region,
+          version: self.data.v3 ? CLOUD_OPENRC_VERSION.V3 : CLOUD_OPENRC_VERSION.V2,
           download: 1,
         }),
       ].join('');

--- a/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.html
+++ b/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.html
@@ -35,6 +35,13 @@
                         <i class="oui-icon oui-icon-chevron-down" aria-hidden="true"></i>
                     </label>
                 </div>
+                <oui-field>
+                    <oui-checkbox
+                        id="version"
+                        data-text="{{ ::'cpou_openrc_form_version3' | translate }}"
+                        data-model="OpenstackUsersOpenrcCtrl.data.v3">
+                    </oui-checkbox>
+                </oui-field>
             </div>
         </div>
     </div>

--- a/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.html
+++ b/client/app/cloud/project/openstack/users/openrc/openstack-users-openrc.html
@@ -37,7 +37,7 @@
                 </div>
                 <oui-field>
                     <oui-checkbox
-                        id="version"
+                        name="version"
                         data-text="{{ ::'cpou_openrc_form_version3' | translate }}"
                         data-model="OpenstackUsersOpenrcCtrl.data.v3">
                     </oui-checkbox>

--- a/client/app/cloud/project/openstack/users/openrc/translations/Messages_fr_FR.xml
+++ b/client/app/cloud/project/openstack/users/openrc/translations/Messages_fr_FR.xml
@@ -5,6 +5,7 @@
    <translation id="cpou_openrc_more" qtlid="44536">En savoir plus</translation>
    <translation id="cpou_openrc_form_select_region" qtlid="263806">Sélectionner la région dans laquelle ce fichier s'appliquera :</translation>
    <translation id="cpou_openrc_form_select_region_placeholder" qtlid="263819">Sélectionner la région</translation>
+   <translation id="cpou_openrc_form_version3">Utiliser le fichier de configuration OpenRC v3</translation>
    <translation id="cpou_openrc_getopenrc_success" qtlid="263832">Téléchargement du fichier de configuration en cours</translation>
    <translation id="cpou_openrc_getopenrc_error" qtlid="263845">Oups! nous n'arrivons pas à télécharger le fichier de configuration</translation>
 </translations>


### PR DESCRIPTION
Close MBP-61

### Requirements

openRC supports version3 file download. This support is to be added to the OpenRC file download dialog, as a checkbox, and version3 should be disabled by default.

## openRC v3 file download


### Description of the Change

The version3 file download support has been added and it is false by default.