### PR TITLE
fix(add-server): inconsistent select-picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
-    "ovh-ui-angular": "~2.22.0",
+    "ovh-ui-angular": "~2.22.1",
     "ovh-ui-kit": "~2.22.0",
     "popper.js": "^1.14.1",
     "uri.js": "medialize/URI.js#~1.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7723,10 +7723,10 @@ ovh-manager-webfont@ovh-ux/ovh-manager-webfont#^1.0.1:
   version "1.0.2"
   resolved "https://codeload.github.com/ovh-ux/ovh-manager-webfont/tar.gz/1d759c46c8c3ead4bc5e887a2336abd124a17c58"
 
-ovh-ui-angular@~2.22.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-2.22.0.tgz#5f020ed4cc4481cb496362ba129d35a1a6b21c60"
-  integrity sha512-Dynr0CO/5Tz/vHPKeXk3AaSuUTRc6hO4YgfBKFZ0sMlw5tTtdDTtTyLADchX06SHyFmgjILefVpK5atw1Iscrg==
+ovh-ui-angular@~2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-2.22.1.tgz#63d9ecb786bb872766b82a29c899dcb40b932eeb"
+  integrity sha512-zAGLqCvL/uuByVMGwQ8Odpf4hJ0Uhq92NT66ov249V+qh1YZGrgAaMEw4lBYXMZN9V6UQLsFdtIPXuyiNbwdYw==
   dependencies:
     angular ">=1.6.x"
     angular-aria ">=1.6.x"


### PR DESCRIPTION
Close MBP-34

### Requirements

When a OS (with multiple versions) is selected, the UI behaves inconsistently

## OS selection - Inconsistent behaviour


### Description of the Change

This issue is because of a bug in the select-picker component, where there are non-distinct values for radio buttons, when the OS has multiple versions. This has been fixed via a patch release in the select-picker component - https://github.com/ovh-ux/ovh-ui-angular/pull/317

**Links** (package update in other managers)
https://github.com/ovh-ux/ovh-manager-dedicated/pull/803
https://github.com/ovh-ux/ovh-manager-web/pull/777
https://github.com/ovh-ux/ovh-manager-telecom/pull/1122