### PR TITLE
fix(vps.upgrade): previous state

### DIFF
--- a/client/app/vps/upgrade/vps-upgrade.controller.js
+++ b/client/app/vps/upgrade/vps-upgrade.controller.js
@@ -25,8 +25,8 @@ class VpsUpgradeCtrl {
     this.upgradesList = null;
   }
 
-  $onInit() {
-    this.previousState = this.CloudNavigation.getPreviousState();
+  gotoPreviousState() {
+    return this.CloudNavigation.getPreviousState().go();
   }
 
   getCurrentModel() {
@@ -59,7 +59,7 @@ class VpsUpgradeCtrl {
         } else {
           this.CloudMessage.error(this.$translate.instant('vps_configuration_upgradevps_fail'));
         }
-        this.previousState.go();
+        this.gotoPreviousState();
       }).finally(() => {
         this.loaders.step1 = false;
       });
@@ -105,7 +105,7 @@ class VpsUpgradeCtrl {
   }
 
   cancel() {
-    this.previousState.go();
+    this.gotoPreviousState();
   }
 
   confirm() {


### PR DESCRIPTION
Close MBP-148

### Requirements

When VPS upgrade errors out, we are redirected to the previous state of the browser history. But when this happens, the previous state is skipped and the browser is redirected to the previous state of the previous state. This has to be fixed.

## VPS Upgrade - Previous State Fix


### Description of the Change

The issue happens because the previous state is being retrieved even before the transition to the upgrade page is complete. This results in the CloudNavigation history returning the wrong previous state. This has been fixed by retrieving the previous state only at the point when it is actually required.