### PR TITLE
fix(servers.add-server): region selection color

### DIFF
--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
@@ -25,7 +25,8 @@
                                                data-picture="assets/images/cloud/os/{{ distribution }}_50.png"
                                                data-text="{{:: 'cpcivm_add_distribution_' + distribution | translate }}{{ imageType === 'windows' ? ' *' : '' }}"
                                                data-values="images"
-                                               data-on-change="$ctrl.onSelectChange()">
+                                               data-on-change="$ctrl.onSelectChange()"
+                                               data-variant="light">
                             </oui-select-picker>
                         </div>
                     </div>
@@ -49,7 +50,8 @@
                                                data-placeholder="{{ 'cpcivm_add_step1_distribution_choose' | translate }}"
                                                data-picture="assets/images/cloud/apps/{{ app.applications[0] || 'unknown' }}.png"
                                                data-text="{{ app.appName }}"
-                                               data-values="[app]">
+                                               data-values="[app]"
+                                               data-variant="light">
                             </oui-select-picker>
                         </div>
                     </div>
@@ -65,7 +67,8 @@
                                                data-name="snapshot"
                                                data-picture="fa fa-2x fa-{{ snapshot.type }}"
                                                data-text="{{ snapshot.name }}"
-                                               data-values="[snapshot]">
+                                               data-values="[snapshot]"
+                                               data-variant="light">
                             </oui-select-picker>
                         </div>
                     </div>
@@ -81,7 +84,8 @@
                                        data-name="imageTypeSelected"
                                        data-picture="assets/images/cloud/{{ $ctrl.model.imageType.apps ? 'apps/' + ($ctrl.model.imageType.applications[0] || 'unknown') : 'os/' + $ctrl.model.imageType.distribution + '_50' }}.png"
                                        data-text="{{:: $ctrl.model.imageType.apps ? $ctrl.model.imageType.appName : 'cpcivm_add_distribution_' + $ctrl.model.imageType.distribution | translate }}"
-                                       data-values="[$ctrl.model.imageType]">
+                                       data-values="[$ctrl.model.imageType]"
+                                       data-variant="light">
                     </oui-select-picker>
                     <oui-select-picker data-ng-if="$ctrl.CloudImageService.constructor.isSnapshot($ctrl.model.imageType)"
                                        data-match="name"
@@ -89,7 +93,8 @@
                                        data-name="snapshotSelected"
                                        data-picture="fa fa-2x fa-{{ $ctrl.model.imageType.type }}"
                                        data-text="{{ $ctrl.model.imageType.name }}"
-                                       data-values="[$ctrl.model.imageType]">
+                                       data-values="[$ctrl.model.imageType]"
+                                       data-variant="light">
                     </oui-select-picker>
                 </div>
             </div>
@@ -257,10 +262,11 @@
                         <div class="cui-grid-list">
                             <div class="cui-grid-list-item cui-grid-cell"
                                  data-ng-repeat="flavor in group.flavors track by flavor.id">
-                                <oui-radio data-id="flavor_{{ flavor.id }}"
-                                           data-disabled="flavor.disabled"
-                                           data-thumbnail
-                                           data-value="flavor">
+                                 <oui-radio class="oui-radio_thumbnail-light"
+                                            data-id="flavor_{{ flavor.id }}"
+                                            data-disabled="flavor.disabled"
+                                            data-thumbnail
+                                            data-value="flavor">
                                     {{flavor.name}}
                                     <span class="oui-radio__section">
                                         <span class="d-flex flex-wrap">
@@ -332,7 +338,8 @@
             <div class="cui-grid-list"
                  data-ng-if="$ctrl.submitted.step3 && $ctrl.model.flavor">
                 <div class="cui-grid-cell">
-                    <oui-radio data-model="$ctrl.model.flavor"
+                    <oui-radio class="oui-radio_thumbnail-light"
+                               data-model="$ctrl.model.flavor"
                                data-name="flavorSelected"
                                data-value="$ctrl.model.flavor"
                                data-thumbnail>
@@ -464,7 +471,8 @@
                 <div class="cui-grid-list">
                     <div class="cui-grid-list-item cui-grid-cell"
                          data-ng-repeat="period in $ctrl.enums.billingPeriods track by $index">
-                        <oui-radio data-id="period_{{period}}"
+                        <oui-radio class="oui-radio_thumbnail-light"
+                                   data-id="period_{{period}}"
                                    data-thumbnail
                                    data-value="period">
                             {{:: 'cpcivm_add_step5_billing_period_' + period | translate}}
@@ -484,7 +492,8 @@
             <div class="cui-grid-list"
                  data-ng-if="$ctrl.submitted.step5 && $ctrl.model.billingPeriod">
                 <div class="cui-grid-cell">
-                    <oui-radio data-text="{{:: 'cpcivm_add_step5_billing_period_' + $ctrl.model.billingPeriod | translate}}"
+                    <oui-radio class="oui-radio_thumbnail-light"
+                               data-text="{{:: 'cpcivm_add_step5_billing_period_' + $ctrl.model.billingPeriod | translate}}"
                                data-model="$ctrl.model.billingPeriod"
                                data-name="billingPeriodSelected"
                                data-value="$ctrl.model.billingPeriod"

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
@@ -175,7 +175,8 @@
                                                data-picture="flag-icon flag-icon-{{ region.macroRegion.code | lowercase }}"
                                                data-placeholder="{{ 'cpcivm_add_step2_datacenter_choose' | translate }}"
                                                data-text="{{region.macroRegion.text}}"
-                                               data-values="region.dataCenters">
+                                               data-values="region.dataCenters"
+                                               data-variant="light">
                                 <span class="oui-select-picker__section text-center"
                                       data-ng-if="region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled">
                                     <oui-button data-variant="link"
@@ -205,7 +206,8 @@
                                                data-picture="flag-icon flag-icon-{{ region.macroRegion.code | lowercase }} flag"
                                                data-placeholder="{{ 'cpcivm_add_step2_datacenter_choose' | translate }}"
                                                data-text="{{ region.macroRegion.text }}"
-                                               data-values="region.dataCenters">
+                                               data-values="region.dataCenters"
+                                               data-variant="light">
                                 <span class="oui-select-picker__section text-center"
                                       data-ng-if="region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled">
                                     <oui-button data-variant="link"
@@ -231,7 +233,8 @@
                                        data-name="regionSelected"
                                        data-picture="flag-icon flag-icon-{{ $ctrl.model.region.macroRegion.code | lowercase }} flag"
                                        data-text="{{ $ctrl.model.region.macroRegion.text }}"
-                                       data-values="[$ctrl.model.region]">
+                                       data-values="[$ctrl.model.region]"
+                                       data-variant="light">
                     </oui-select-picker>
                 </div>
             </div>

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
@@ -262,10 +262,10 @@
                         <div class="cui-grid-list">
                             <div class="cui-grid-list-item cui-grid-cell"
                                  data-ng-repeat="flavor in group.flavors track by flavor.id">
-                                 <oui-radio class="oui-radio_thumbnail-light"
-                                            data-id="flavor_{{ flavor.id }}"
+                                 <oui-radio data-id="flavor_{{ flavor.id }}"
                                             data-disabled="flavor.disabled"
                                             data-thumbnail
+                                            data-variant="light"
                                             data-value="flavor">
                                     {{flavor.name}}
                                     <span class="oui-radio__section">
@@ -338,11 +338,11 @@
             <div class="cui-grid-list"
                  data-ng-if="$ctrl.submitted.step3 && $ctrl.model.flavor">
                 <div class="cui-grid-cell">
-                    <oui-radio class="oui-radio_thumbnail-light"
-                               data-model="$ctrl.model.flavor"
+                    <oui-radio data-model="$ctrl.model.flavor"
                                data-name="flavorSelected"
                                data-value="$ctrl.model.flavor"
-                               data-thumbnail>
+                               data-thumbnail
+                               data-variant="light">
                         {{$ctrl.model.flavor.name}}
                         <span class="oui-radio__section">
                             <span class="d-flex flex-wrap">
@@ -471,10 +471,10 @@
                 <div class="cui-grid-list">
                     <div class="cui-grid-list-item cui-grid-cell"
                          data-ng-repeat="period in $ctrl.enums.billingPeriods track by $index">
-                        <oui-radio class="oui-radio_thumbnail-light"
-                                   data-id="period_{{period}}"
+                        <oui-radio data-id="period_{{period}}"
                                    data-thumbnail
-                                   data-value="period">
+                                   data-value="period"
+                                   data-variant="light">
                             {{:: 'cpcivm_add_step5_billing_period_' + period | translate}}
                             <span class="oui-radio__section"
                                   data-translate="cpci_vm_flavor_price"
@@ -492,12 +492,12 @@
             <div class="cui-grid-list"
                  data-ng-if="$ctrl.submitted.step5 && $ctrl.model.billingPeriod">
                 <div class="cui-grid-cell">
-                    <oui-radio class="oui-radio_thumbnail-light"
-                               data-text="{{:: 'cpcivm_add_step5_billing_period_' + $ctrl.model.billingPeriod | translate}}"
+                    <oui-radio data-text="{{:: 'cpcivm_add_step5_billing_period_' + $ctrl.model.billingPeriod | translate}}"
                                data-model="$ctrl.model.billingPeriod"
                                data-name="billingPeriodSelected"
                                data-value="$ctrl.model.billingPeriod"
-                               data-thumbnail>
+                               data-thumbnail
+                               data-variant="light">
                         <span class="oui-radio__section"
                               data-translate="cpci_vm_flavor_price"
                               data-translate-values="{ price: (($ctrl.model.number * $ctrl.model.flavor.price.price.value) | currency: $ctrl.currentCurrency: 3) || '?' }"


### PR DESCRIPTION
Close MBE-185

### Requirements

The region selection tiles should have blue background only when selected.

## Title of the Pull Requests <!-- required -->


### Description of the Change

The select-picker variant has been updated so that the tiles appear white when not selected and appears blue when selected.