### PR TITLE
refactor(package.json): use start:eu as default start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:css": "stylelint 'client/**/*.less' --fix",
     "lint:html": "htmlhint --ignore '**/noVNC/**' 'client/**/*.html'",
     "lint:js": "eslint --quiet --fix ./client",
-    "start": "webpack-dev-server --env.region=eu",
+    "start": "yarn run start:eu",
     "start:ca": "webpack-dev-server --env.region=ca",
     "start:eu": "webpack-dev-server --env.region=eu",
     "start:us": "webpack-dev-server --env.region=us",


### PR DESCRIPTION
## use `start:eu` 🇪🇺 as default start script 🏁 

### Description of the Change

337f84b — refactor(package.json): use start:eu as default start script