### PR TITLE
fix(load-balancer): apply configuration error

### DIFF
--- a/client/app/iplb/configuration/iplb-configuration.service.js
+++ b/client/app/iplb/configuration/iplb-configuration.service.js
@@ -70,7 +70,7 @@ class IpLoadBalancerConfigurationService {
       zone,
     })
       .$promise
-      .then(this.ServiceHelper.successHandler('iplb_configuration_apply_success'))
+      .then(() => this.ServiceHelper.successHandler('iplb_configuration_apply_success')())
       .catch(this.ServiceHelper.errorHandler('iplb_configuration_apply_error'));
   }
 
@@ -81,7 +81,7 @@ class IpLoadBalancerConfigurationService {
       zone,
     }).$promise);
     return this.$q.all(promises)
-      .then(this.ServiceHelper.successHandler('iplb_configuration_apply_success'))
+      .then(() => this.ServiceHelper.successHandler('iplb_configuration_apply_success')())
       .catch(this.ServiceHelper.errorHandler('iplb_configuration_apply_error'));
   }
 


### PR DESCRIPTION
Close MBP-141

### Requirements

Apply Configuration for Load balancer results in a error

## Load Balancer Apply Configuration fix


### Description of the Change

The apply configuration success callback has a call to ServiceHelper.successHandler. Since ServiceHelper.successHandler returns a function, the value that the promise resolves with is passed to this function. This value has a recursive object, which causes the problem when used with $translate.instant method. 

This problem is fixed by explicitly calling the function returned by ServiceHelper.successHandler, with no parameter (no data is required for this particular success message).