### PR TITLE
feat: support APAC region in PCI

### DIFF
--- a/client/app/app.less
+++ b/client/app/app.less
@@ -275,6 +275,7 @@ html {
 @import "cloud/project/compute/infrastructure/volume/addEdit/cloud-project-compute-infrastructure-volume-addEdit.less";
 @import "cloud/project/compute/loadbalancer/cloud-project-compute-loadbalancer.less";
 @import "cloud/project/compute/quota/cloud-project-compute-quota.less";
+@import "cloud/project/compute/regions/regions.less";
 @import "cloud/project/compute/ssh/cloud-project-compute-ssh.less";
 @import "cloud/project/details/cloud-project-details.less";
 @import "cloud/project/openstack/openstack.less";

--- a/client/app/cloud/project/compute/cloud-project-compute.html
+++ b/client/app/cloud/project/compute/cloud-project-compute.html
@@ -31,6 +31,9 @@
                 <cui-tab data-text="'cloud_sidebar_pci_openstack'|translate"
                          data-state="iaas.pci-project.compute.openstack"
                          data-state-params="{ serviceName: CloudProjectComputeCtrl.serviceName }"></cui-tab>
+                <cui-tab data-text="'cloud_sidebar_pci_regions'|translate"
+                         data-state="iaas.pci-project.compute.regions"
+                         data-state-params="{ serviceName: CloudProjectComputeCtrl.serviceName }"></cui-tab>
             </cui-tabs>
         </cui-page-header>
 

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
@@ -189,7 +189,7 @@
                                                 data-on-click="$ctrl.updateSshKeyRegion()"
                                                 data-ng-if="$ctrl.model.sshKey && ($ctrl.model.region.disabled === 'SSH_KEY' || (region.dataCenters.length === 1 && region.dataCenters[0].disabled === 'SSH_KEY'))">
                                     </oui-button>
-                                    <span data-translate="'cpcivm_add_step2_disabled_' + region.disabled"
+                                    <span data-ng-bind="{{ ::'cpcivm_add_step2_disabled_' + region.disabled | translate }}"
                                           data-ng-if="(region.dataCenters.length === 1 && region.dataCenters[0].disabled !== 'SSH_KEY') || $ctrl.model.region.disabled === 'SSH_KEY'">
                                     </span>
                                 </span>
@@ -220,7 +220,7 @@
                                                 data-on-click="$ctrl.updateSshKeyRegion()"
                                                 data-ng-if="$ctrl.model.sshKey && ($ctrl.model.region.disabled === 'SSH_KEY' || (region.dataCenters.length === 1 && region.dataCenters[0].disabled === 'SSH_KEY'))">
                                     </oui-button>
-                                    <span data-translate="'cpcivm_add_step2_disabled_' + region.disabled"
+                                    <span data-ng-bind="{{ ::'cpcivm_add_step2_disabled_' + region.disabled | translate }}"
                                           data-ng-if="(region.dataCenters.length === 1 && region.dataCenters[0].disabled !== 'SSH_KEY') || $ctrl.model.region.disabled === 'SSH_KEY'">
                                     </span>
                                 </span>

--- a/client/app/cloud/project/compute/regions/regions.controller.js
+++ b/client/app/cloud/project/compute/regions/regions.controller.js
@@ -1,0 +1,117 @@
+class RegionsCtrl {
+  constructor(
+    $stateParams,
+    CloudMessage,
+    ServiceHelper,
+    ControllerHelper,
+    OvhApiCloudProjectRegion,
+    CloudProjectVirtualMachineAddService,
+    RegionService,
+  ) {
+    this.CloudMessage = CloudMessage;
+    this.ControllerHelper = ControllerHelper;
+    this.OvhApiCloudProjectRegion = OvhApiCloudProjectRegion;
+    this.RegionService = RegionService;
+    this.ServiceHelper = ServiceHelper;
+    this.VirtualMachineAddService = CloudProjectVirtualMachineAddService;
+    this.serviceName = $stateParams.projectId;
+  }
+
+  $onInit() {
+    this.availableRegionToAdd = null;
+    this.initLoaders();
+  }
+
+  initLoaders() {
+    // load regions
+    this.initRegions();
+    this.initRegionsByDatacenter();
+    this.initRegionsByContinent();
+    // load available regions
+    this.initAvailableRegions();
+    this.initAvailableRegionsByDatacenter();
+    this.initAvailableRegionsByContinent();
+  }
+
+  initRegions() {
+    this.regions = this.ControllerHelper.request.getHashLoader({
+      loaderFunction: () => this.OvhApiCloudProjectRegion.v6()
+        .query({ serviceName: this.serviceName })
+        .$promise
+        .then(regionIds => _.map(regionIds, region => this.RegionService.getRegion(region)))
+        .catch(error => this.ServiceHelper.errorHandler('cpci_add_regions_get_regions_error')(error)),
+    });
+    return this.regions.load();
+  }
+
+  initRegionsByDatacenter() {
+    this.regionsByDatacenter = this.ControllerHelper.request.getHashLoader({
+      loaderFunction: () => this.regions
+        .promise
+        .then(regions => this.VirtualMachineAddService.constructor.groupRegionsByDatacenter(
+          regions,
+        )),
+    });
+    return this.regionsByDatacenter.load();
+  }
+
+  initRegionsByContinent() {
+    this.regionsByContinent = this.ControllerHelper.request.getHashLoader({
+      loaderFunction: () => this.regionsByDatacenter
+        .promise
+        .then(regions => _.groupBy(regions, 'continent')),
+    });
+    return this.regionsByContinent.load();
+  }
+
+  initAvailableRegions() {
+    this.availableRegions = this.ControllerHelper.request.getHashLoader({
+      loaderFunction: () => this.OvhApiCloudProjectRegion.AvailableRegions().v6()
+        .query({ serviceName: this.serviceName })
+        .$promise
+        .then(regionIds => _.map(regionIds, region => this.RegionService.getRegion(region.name)))
+        .catch(error => this.ServiceHelper.errorHandler('cpci_add_regions_get_available_regions_error')(error)),
+    });
+    return this.availableRegions.load();
+  }
+
+  initAvailableRegionsByDatacenter() {
+    this.availableRegionsByDatacenter = this.ControllerHelper.request.getHashLoader({
+      loaderFunction: () => this.availableRegions
+        .promise
+        .then(regions => this.VirtualMachineAddService.constructor.groupRegionsByDatacenter(
+          regions,
+        )),
+    });
+    return this.availableRegionsByDatacenter.load();
+  }
+
+  initAvailableRegionsByContinent() {
+    this.availableRegionsByContinent = this.ControllerHelper.request.getHashLoader({
+      loaderFunction: () => this.availableRegionsByDatacenter
+        .promise
+        .then(regions => _.groupBy(regions, 'continent')),
+    });
+    return this.availableRegionsByContinent.load();
+  }
+
+  addRegions() {
+    this.CloudMessage.flushChildMessage();
+    this.addRegion = this.ControllerHelper.request.getHashLoader({
+      loaderFunction: () => this.OvhApiCloudProjectRegion.v6()
+        .addRegion({ serviceName: this.serviceName },
+          { region: this.availableRegionToAdd.microRegion.code })
+        .$promise
+        .then(() => this.OvhApiCloudProjectRegion.AvailableRegions().v6().resetQueryCache())
+        .then(() => this.initLoaders())
+        .then(() => this.ServiceHelper.successHandler('cpci_add_regions_add_region_success')({
+          code: this.availableRegionToAdd.microRegion.code,
+        }))
+        .catch(error => this.ServiceHelper.errorHandler('cpci_add_regions_add_region_error')(error))
+        .finally(() => this.ControllerHelper.scrollPageToTop()),
+    });
+    this.addRegion.load();
+  }
+}
+
+angular.module('managerApp').controller('RegionsCtrl', RegionsCtrl);

--- a/client/app/cloud/project/compute/regions/regions.html
+++ b/client/app/cloud/project/compute/regions/regions.html
@@ -1,0 +1,122 @@
+<section class="cui-page__content cloud-compute__regions">
+    <h3 data-translate="cpci_add_regions_title"></h3>
+    <p data-translate="cpci_add_regions_description"></p>
+
+    <oui-message data-type="info"
+        data-dismissable="false"
+        class="regions-info-message">
+        <span data-translate="cpci_add_regions_info_message"></span>
+    </oui-message>
+
+    <!-- regions added -->
+    <h6 data-translate="cpci_add_regions_added_title"></h6>
+    <oui-spinner data-size="s"
+        data-ng-if="$ctrl.regionsByDatacenter.loading || $ctrl.regionsByContinent.loading"></oui-spinner>
+    <oui-tabs data-ng-if="!$ctrl.regionsByDatacenter.loading || !$ctrl.regionsByContinent.loading">
+        <oui-tabs-item data-heading="{{ ::'cpcivm_add_step2_tab_all' | translate }}">
+            <div class="cui-grid-list">
+                <div class="cui-grid-list-item cui-grid-cell"
+                    data-ng-repeat="region in $ctrl.regionsByDatacenter.data track by region.macroRegion.code">
+                    <oui-select-picker data-id="region_{{ region.macroRegion.code }}"
+                        data-disabled="true"
+                        data-name="region"
+                        data-picture="flag-icon flag-icon-{{
+                            region.macroRegion.code | lowercase
+                        }}"
+                        data-label="{{ ::region.macroRegion.text }}"
+                        data-variant="light">
+                        <oui-select-picker-section data-ng-repeat="datacenter in region.dataCenters track by datacenter.microRegion.code">
+                            <span data-ng-bind="datacenter.microRegion.text"></span>
+                        </oui-select-picker-section>
+                    </oui-select-picker>
+                </div>
+            </div>
+        </oui-tabs-item>
+        <oui-tabs-item data-ng-repeat="(continent, regions) in $ctrl.regionsByContinent.data track by $index"
+            data-heading="{{ ::continent }}"
+            data-index="($index + 1)">
+            <div class="cui-grid-list">
+                <div class="cui-grid-list-item cui-grid-cell"
+                    data-ng-repeat="region in regions track by region.macroRegion.code">
+                    <oui-select-picker data-id="region_{{ region.macroRegion.code }}"
+                        data-disabled="true"
+                        data-name="region"
+                        data-picture="flag-icon flag-icon-{{
+                            region.macroRegion.code | lowercase
+                        }}"
+                        data-label="{{ ::region.macroRegion.text }}"
+                        data-variant="light">
+                        <oui-select-picker-section data-ng-repeat="datacenter in region.dataCenters track by datacenter.microRegion.code">
+                            <span data-ng-bind="datacenter.microRegion.text"></span>
+                        </oui-select-picker-section>
+                    </oui-select-picker>
+                </div>
+            </div>
+        </oui-tabs-item>
+    </oui-tabs>
+
+    <!-- available regions to add -->
+    <h6 class="mt-5"
+        data-translate="cpci_add_regions_available_to_add_title"></h6>
+    <oui-spinner data-size="s"
+        data-ng-if="$ctrl.availableRegionsByDatacenter.loading || $ctrl.availableRegionsByContinent.loading"></oui-spinner>
+    <p data-translate="cpci_add_regions_all_added"
+        data-ng-if="$ctrl.availableRegionsByDatacenter.data.length === 0"></p>
+    <div data-ng-if="$ctrl.availableRegionsByDatacenter.data.length > 0">
+        <oui-tabs>
+            <oui-tabs-item data-heading="{{ ::'cpcivm_add_step2_tab_all' | translate }}">
+                <div class="cui-grid-list">
+                    <div class="cui-grid-list-item cui-grid-cell"
+                        data-ng-repeat="region in $ctrl.availableRegionsByDatacenter.data track by region.macroRegion.code">
+                        <oui-select-picker data-id="availableRegion_{{
+                                region.macroRegion.code
+                            }}"
+                            data-match="microRegion.text"
+                            data-model="$ctrl.availableRegionToAdd"
+                            data-name="allAvailableRegions"
+                            data-picture="flag-icon flag-icon-{{
+                                region.macroRegion.code | lowercase
+                            }}"
+                            data-label="{{ ::region.macroRegion.text }}"
+                            data-values="region.dataCenters"
+                            data-variant="light">
+                        </oui-select-picker>
+                    </div>
+                </div>
+            </oui-tabs-item>
+            <oui-tabs-item data-ng-repeat="(continent, regions)  in $ctrl.availableRegionsByContinent.data track by $index"
+                data-heading="{{ continent }}"
+                index="($index + 1)">
+                <div class="cui-grid-list">
+                    <div class="cui-grid-list-item cui-grid-cell"
+                        data-ng-repeat="region in regions track by region.macroRegion.code">
+                        <oui-select-picker data-id="availableRegion__{{
+                                region.macroRegion.code
+                            }}"
+                            data-match="microRegion.text"
+                            data-model="$ctrl.availableRegionToAdd"
+                            data-name="availableRegion"
+                            data-picture="flag-icon flag-icon-{{
+                                region.macroRegion.code | lowercase
+                            }} flag"
+                            data-label="{{ region.macroRegion.text }}"
+                            data-values="region.dataCenters"
+                            data-variant="light">
+                        </oui-select-picker>
+                    </div>
+                </div>
+            </oui-tabs-item>
+        </oui-tabs>
+
+        <!-- add regions button -->
+        <oui-button class="mt-5"
+            data-variant="primary"
+            data-type="button"
+            data-on-click="$ctrl.addRegions()"
+            data-disabled="$ctrl.availableRegionToAdd === null"
+            data-ng-if="!$ctrl.addRegion.loading">
+            <span data-translate="cpci_add_regions_add_region"></span>
+        </oui-button>
+        <oui-spinner data-ng-if="$ctrl.addRegion.loading"></oui-spinner>
+    </div>
+</section>

--- a/client/app/cloud/project/compute/regions/regions.js
+++ b/client/app/cloud/project/compute/regions/regions.js
@@ -1,0 +1,18 @@
+angular.module('managerApp')
+  .config(($stateProvider) => {
+    $stateProvider
+      .state('iaas.pci-project.compute.regions', {
+        url: '/regions',
+        views: {
+          cloudProjectCompute: {
+            templateUrl: 'app/cloud/project/compute/regions/regions.html',
+            controller: 'RegionsCtrl',
+            controllerAs: '$ctrl',
+          },
+        },
+        translations: {
+          value: ['.', './../infrastructure/virtualMachine/add'],
+          format: 'json',
+        },
+      });
+  });

--- a/client/app/cloud/project/compute/regions/regions.less
+++ b/client/app/cloud/project/compute/regions/regions.less
@@ -1,0 +1,5 @@
+.cloud-compute__regions {
+  .regions-info-message .oui-message {
+    margin: 0 0 1.6rem;
+  }
+}

--- a/client/app/cloud/project/compute/regions/translations/Messages_fr_FR.json
+++ b/client/app/cloud/project/compute/regions/translations/Messages_fr_FR.json
@@ -1,0 +1,13 @@
+{
+  "cpci_add_regions_title": "Ajouter des régions",
+  "cpci_add_regions_description": "OVH vous propose plusieurs régions pour créer vos infrastructures ou créer un conteneur. Par défaut vous avez accès à quelques régions mais vous pouvez choisir d'ajouter de nouvelles régions.",
+  "cpci_add_regions_added_title": "Régions disponibles",
+  "cpci_add_regions_available_to_add_title": "Régions que vous pouvez ajouter",
+  "cpci_add_regions_add_region": "Ajouter une région",
+  "cpci_add_regions_get_regions_error": "Impossible de récupérer les régions: {{message}}",
+  "cpci_add_regions_get_available_regions_error": "Échec d'extraction des régions disponibles: {{message}}",
+  "cpci_add_regions_add_region_error": "Impossible d'ajouter la région: {{message}}",
+  "cpci_add_regions_add_region_success": "Région {{code}} ajoutée",
+  "cpci_add_regions_all_added": "Toutes les régions ajoutées",
+  "cpci_add_regions_info_message": "L'ajout de nouvelles régions peut prendre un certain temps, de l'ordre de quelques minutes. Une fois ces régions ajoutées vous pourrez y ajouter un serveur ou un conteneur."
+}

--- a/client/components/sidebar/translations/Messages_fr_FR.json
+++ b/client/components/sidebar/translations/Messages_fr_FR.json
@@ -30,6 +30,7 @@
   "cloud_sidebar_pci_object_storage": "Stockage",
   "cloud_sidebar_pci_manage": "Gestion du projet",
   "cloud_sidebar_pci_openstack": "Openstack",
+  "cloud_sidebar_pci_regions": "Les régions",
   "cloud_sidebar_server_more": "Gérer les {{count}} services",
   "cloud_sidebar_section_metrics": "Metrics",
   "cloud_sidebar_dbaasts_tokens": "Clés d'API",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "ovh-angular-tail-logs": "ovh-ux/ovh-angular-tail-logs#^1.1.2",
     "ovh-angular-toaster": "ovh-ux/ovh-angular-toaster#^0.8.0",
     "ovh-angular-user-pref": "ovh-ux/ovh-angular-user-pref#^0.3.1",
-    "ovh-api-services": "^3.24.0",
+    "ovh-api-services": "^3.28.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7397,10 +7397,10 @@ ovh-angular-user-pref@ovh-ux/ovh-angular-user-pref#^0.3.1:
   version "0.3.1"
   resolved "https://codeload.github.com/ovh-ux/ovh-angular-user-pref/tar.gz/71d0b3c0606a2e2052505bda2a8e2ff06b0156e1"
 
-ovh-api-services@^3.24.0:
-  version "3.24.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.24.0.tgz#a0ed96b70f23dcdc26b1bfaa26890cc3939d4270"
-  integrity sha512-jo2Jb73Vpy0rKz6Z/qq5b1GAbfu3ayVRKg7yVJmdRnahVYx7QQ5ne7SJQq4xersQh9CAC5TQNr79w0I1p1VLBw==
+ovh-api-services@^3.28.0:
+  version "3.28.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.28.0.tgz#b2869540d6e99ba883e9916cf73ed3395a4c8293"
+  integrity sha512-30HT2bGWB3jh+cw+KYHLCvUnBLjQgZ8x6Wu+Q8J8U846/GUHSKeYSBk4TWEEcJC06HJkXVrZMYzwq/ITr+UIWA==
   dependencies:
     lodash "^3.10.1"
 


### PR DESCRIPTION


add UI page to show and add available regions

Closes #MANAGER-1342

### Note

This PR is a replacement of PR https://github.com/ovh-ux/ovh-manager-cloud/pull/1238. Old PR had my changes on top of Varun's revamp menu changes. Since his changes are not going to production, I had to create a new PR only with my changes. All comments in old PR are taken care.

## Title of the Pull Requests <!-- required -->
APAC region support in PCI

### Description of the Change
Added new UI page to

List all added and available regions
The user can add available regions. These regions will appear while new/edit server page


### Benefits
PCI will be available in APAC region for customers to use
The users in Europe can add the server in APAC region
The users in APAC can add the server in Europe region

### Possible Drawbacks
none

### Applicable Issues
MANAGER-1342
