### PR TITLE
fix(server-vm-add): option to hide unavailable flavors

### DIFF
--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
@@ -256,7 +256,9 @@
                          index="$index" heading="{{ 'cpcivm_add_step3_category_' + group.category | translate }}">
                     <p class="my-4"
                        data-ng-bind=":: 'cpcivm_add_step3_category_definition_' + group.category | translate"></p>
-
+                    <oui-checkbox data-model="$ctrl.hideUnavailableOptions">
+                        <span data-translate="cpcivm_add_step3_hide_unavailable"></span>
+                    </oui-checkbox>
                     <oui-radio-group data-model="$ctrl.model.flavor"
                                      data-name="flavor">
                         <div class="cui-grid-list">
@@ -264,6 +266,7 @@
                                  data-ng-repeat="flavor in group.flavors track by flavor.id">
                                  <oui-radio data-id="flavor_{{ flavor.id }}"
                                             data-disabled="flavor.disabled"
+                                            data-ng-if="!(flavor.disabled && $ctrl.hideUnavailableOptions)"
                                             data-thumbnail
                                             data-variant="light"
                                             data-value="flavor">

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/translations/Messages_fr_FR.json
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/translations/Messages_fr_FR.json
@@ -83,6 +83,7 @@
   "cpcivm_add_step3_network_none": "Aucun",
   "cpcivm_add_step3_flavor_prices_ERROR": "Impossible de récupérer les prix des offres disponibles : {{message}}",
   "cpcivm_add_step3_flavors_ERROR": "Impossible de récupérer la liste des offres disponibles : {{message}}",
+  "cpcivm_add_step3_hide_unavailable": "Masquer les options non disponibles",
   "cpcivm_add_step4_title": "Configurer votre instance",
   "cpcivm_add_step5_title": "Sélectionnez une période de facturation",
   "cpcivm_add_step5_message": "Le forfait mensuel est facturé dès le démarrage de l'instance et permet d'économiser 50% sur le prix des serveurs. Pour une utilisation sur de courtes périodes, il est recommandé de choisir la facturation à l'heure et de basculer au forfait mensuel par la suite.",


### PR DESCRIPTION
Close MBP-22

### Requirements

An option to hide unavailable flavors is required, to facilitate simplification of choices

## Checkbox to hide Unavailable Flavors

### Description of the Change

A checkbox has been added to hide the unavailable flavors.