### PR TITLE
feat(kube-nodes): name field addition

### DIFF
--- a/client/app/kubernetes/kubernetes.service.js
+++ b/client/app/kubernetes/kubernetes.service.js
@@ -54,8 +54,11 @@ angular.module('managerApp').service('Kubernetes', class Kubernetes {
     return this.OvhApiKube.PublicCloud().Node().v6().query({ serviceName }).$promise;
   }
 
-  addNode(serviceName, flavorName) {
-    return this.OvhApiKube.PublicCloud().Node().v6().save({ serviceName }, { flavorName }).$promise;
+  addNode(serviceName, name, flavorName) {
+    return this.OvhApiKube.PublicCloud().Node().v6().save(
+      { serviceName },
+      { name, flavorName },
+    ).$promise;
   }
 
   changeMenuTitle(serviceName, name) {

--- a/client/app/kubernetes/nodes/add/kubernetes-nodes-add.controller.js
+++ b/client/app/kubernetes/nodes/add/kubernetes-nodes-add.controller.js
@@ -88,7 +88,7 @@ angular.module('managerApp').controller('KubernetesNodesAddCtrl', class Kubernet
 
   addNode() {
     this.loading = true;
-    return this.Kubernetes.addNode(this.serviceName, this.selectedFlavor.name)
+    return this.Kubernetes.addNode(this.serviceName, this.nodeName, this.selectedFlavor.name)
       .then(() => this.$uibModalInstance.close())
       .catch(error => this.$uibModalInstance.dismiss(this.$translate.instant('kube_nodes_add_error', { message: _.get(error, 'data.message', '') })))
       .finally(() => { this.loading = false; });

--- a/client/app/kubernetes/nodes/add/kubernetes-nodes-add.html
+++ b/client/app/kubernetes/nodes/add/kubernetes-nodes-add.html
@@ -9,6 +9,18 @@
                data-on-dismiss="$ctrl.dismiss()"
                data-loading="$ctrl.loading">
         <p data-translate="kube_nodes_add_region"></p>
+        <oui-field data-label="{{:: 'kube_nodes_add_node_name' | translate }}"
+                   data-error-messages="{ pattern: ('kube_nodes_add_node_name_validation_error' | translate) }"
+                   data-size="auto">
+            <input class="oui-input"
+                   type="text"
+                   id="nodename"
+                   name="nodename"
+                   required
+                   maxlength="50"
+                   data-ng-model="$ctrl.nodeName"
+                   data-ng-pattern="/^[a-z0-9]([-\.a-z0-9]*[a-z0-9])?$/">
+        </oui-field>
         <div class="oui-field"
              data-ng-class="{ 'oui-field_error': kubeNodesAdd.$submitted && !$ctrl.flavorFamily }">
             <label id="flavorFamily" class="oui-label" data-translate="kube_nodes_add_flavor_family"></label>

--- a/client/app/kubernetes/nodes/kubernetes-nodes.controller.js
+++ b/client/app/kubernetes/nodes/kubernetes-nodes.controller.js
@@ -42,6 +42,7 @@ angular.module('managerApp').controller('KubernetesNodesCtrl', class KubernetesN
   }
 
   getInfo() {
+    this.loading = true;
     return this.$q.all(
       this.getNodes(),
       this.getCluster(),

--- a/client/app/kubernetes/nodes/kubernetes-nodes.html
+++ b/client/app/kubernetes/nodes/kubernetes-nodes.html
@@ -9,6 +9,11 @@
             <span data-translate="kube_nodes_description_project_2"></span>
         </p>
         <oui-datagrid data-rows="$ctrl.nodes" data-row-loader="$ctrl.getAssociatedFlavor($row)">
+            <oui-column data-title=":: 'cloud_common_name' | translate"
+                        data-property="name"
+                        data-type="string"
+                        data-searchable
+                        data-filterable></oui-column>
             <oui-column data-title=":: 'kube_nodes_node' | translate"
                         data-property="id"
                         data-type="string"

--- a/client/app/kubernetes/translations/Messages_fr_FR.json
+++ b/client/app/kubernetes/translations/Messages_fr_FR.json
@@ -41,6 +41,8 @@
   "kube_nodes_add_region": "Durant la bêta, vos nœuds seront tous dans la région GRA5. Nous permettrons ultérieurement de choisir cette région.",
   "kube_nodes_add_success": "Le nœud est en cours d'installation",
   "kube_nodes_add_flavor_error": "Une erreur est survenue lors du chargement des modèles d'instance : {{ message }}",
+  "kube_nodes_add_node_name": "Nom de l'instance",
+  "kube_nodes_add_node_name_validation_error": "Le nom de l’instance doit commencer et se terminer par des caractères alphanumériques minuscules (de a à z et de 0 à 9) et peut comporter les signes de ponctuation suivants : « . » et « - ».",
   "kube_nodes_add_flavor_family": "Choisir une famille d'instance",
   "kube_nodes_add_flavor_family_balanced": "General purpose",
   "kube_nodes_add_flavor_family_cpu": "CPU",


### PR DESCRIPTION
Close MBP-244

### Requirements

While create a Kubernetes node, the name field is required for the node.

## Kubernetes Node Name

### Description of the Change

The name field has been added to the node add pop-up. The data grid in the nodes screen now also has the name field.