### PR TITLE
fix(flavor): t1 180 flavor

### DIFF
--- a/client/app/cloud/project/compute/infrastructure/flavor.service.js
+++ b/client/app/cloud/project/compute/infrastructure/flavor.service.js
@@ -162,7 +162,6 @@
 
       const flavorContainsGPUs = _(['g1', 'g2', 'g3', 't1']).includes(augmentedFlavor.shortType);
       if (flavorContainsGPUs) {
-        augmentedFlavor.imageType = flavor.osType === 'windows' ? ['uefi'] : augmentedFlavor.imageType;
         augmentedFlavor.gpuCardCount = _(this.CLOUD_INSTANCE_NUMBER_OF_GPUS).get(
           numberType,
           this.CLOUD_INSTANCE_NUMBER_OF_GPUS.default,


### PR DESCRIPTION
T-180 flavor must be available for all Windows editions. As of now UI only allows UEFI edition.

Closes #MBP-328

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
T1-180 flavor 

### Description of the Change
UI restricted T1-180 flavor to be only available with windows UEFI edition in list view. In the Infrastructure view, it was available with all Windows editions. T1 and other GPU flavors like G1, G2, G3,  must be available with all windows editions unless API sets the restriction. I have removed the restriction at UI side to allow this. 

### Benefits

<!-- optional -->
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
MBP-328
