### PR TITLE
fix(kube-nodes): flavor update post node creation

### DIFF
--- a/client/app/kubernetes/kubernetes.service.js
+++ b/client/app/kubernetes/kubernetes.service.js
@@ -33,13 +33,6 @@ angular.module('managerApp').service('Kubernetes', class Kubernetes {
     return this.OvhApiKube.PublicCloud().Project().v6().query({ serviceName }).$promise;
   }
 
-  getAssociatedInstance(projectId, instanceId) {
-    return this.OvhApiCloudProjectInstance
-      .v6()
-      .get({ serviceName: projectId, instanceId })
-      .$promise;
-  }
-
   getProject(projectId) {
     return this.OvhApiCloudProject.v6().get({ serviceName: projectId }).$promise;
   }

--- a/client/app/kubernetes/nodes/kubernetes-nodes.controller.js
+++ b/client/app/kubernetes/nodes/kubernetes-nodes.controller.js
@@ -56,15 +56,15 @@ angular.module('managerApp').controller('KubernetesNodesCtrl', class KubernetesN
   }
 
   getAssociatedFlavor(node) {
-    if (node.instanceId) {
-      return this.Kubernetes.getAssociatedInstance(node.projectId, node.instanceId)
-        .then(instance => _.set(node, 'formattedFlavor', this.Kubernetes.formatFlavor(instance.flavor)))
-        .catch(() => {
-          _.set(node, 'formattedFlavor', this.$translate.instant('kube_nodes_flavor_error'));
-        });
-    }
-
-    return this.$q.when(_.set(node, 'formattedFlavor', node.flavor));
+    return this.Kubernetes.getFlavors(node.projectId)
+      .then((flavors) => {
+        _.set(node, 'formattedFlavor', this.Kubernetes.formatFlavor(
+          _.find(flavors, { name: node.flavor }),
+        ));
+      })
+      .catch(() => {
+        _.set(node, 'formattedFlavor', this.$translate.instant('kube_nodes_flavor_error'));
+      });
   }
 
   getPublicCloudProject() {


### PR DESCRIPTION
Close MBP-308

### Requirements

After a node is added, the flavor is not updated correctly.

## Kube Node Flavor Update

### Description of the Change

The issue is fixed by updating the flavor by getting the list of flavors and filtering them by the flavor code from the node.