### PR TITLE
feat(regions): show inactive regions

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -1,4 +1,17 @@
 
+// override bootstrap map to add custom widths
+// This variable affects the `.h-*` and `.w-*` classes.
+$sizes: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$sizes: map-merge(
+  (
+    10: 10%,
+    15: 15%,
+    20: 20%
+  ),
+  $sizes
+);
+
 @import '../../node_modules/bs4/scss/_functions.scss';
 @import '../../node_modules/bs4/scss/_variables.scss';
 @import '../../node_modules/bs4/scss/_mixins.scss';

--- a/client/app/cloud/cloud.less
+++ b/client/app/cloud/cloud.less
@@ -8,6 +8,10 @@ img.img-circle-bordered {
   cursor: help;
 }
 
+.cursor-disabled {
+  cursor: not-allowed;
+}
+
 .no-outline:focus {
   outline: 0;
 }

--- a/client/app/cloud/project/compute/infrastructure/cloud-project-compute-infrastructure.js
+++ b/client/app/cloud/project/compute/infrastructure/cloud-project-compute-infrastructure.js
@@ -46,6 +46,7 @@ angular.module('managerApp')
             '../../rename',
             './openstackClient',
             '../../../../vrack/modals',
+            '../../regions',
           ],
           format: 'json',
         },

--- a/client/app/cloud/project/compute/infrastructure/diagram/cloud-project-compute-infrastructure-diagram.js
+++ b/client/app/cloud/project/compute/infrastructure/diagram/cloud-project-compute-infrastructure-diagram.js
@@ -12,7 +12,10 @@ angular.module('managerApp').config(($stateProvider) => {
       },
     },
     translations: {
-      value: ['../../../billing/vouchers/addCredit'],
+      value: [
+        '../../../billing/vouchers/addCredit',
+        '../../regions',
+      ],
       format: 'json',
     },
   });

--- a/client/app/cloud/project/compute/infrastructure/region.service.js
+++ b/client/app/cloud/project/compute/infrastructure/region.service.js
@@ -27,6 +27,14 @@ class CloudRegionService {
       delete region.disabled; // eslint-disable-line
     }
   }
+
+  static isActive(region) {
+    return !region.notAvailable;
+  }
+
+  static setRegionInactiveMessage(region) {
+    _.set(region, 'disabled', 'INACTIVE');
+  }
 }
 
 angular.module('managerApp').service('CloudRegionService', CloudRegionService);

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.html
@@ -167,6 +167,7 @@
                        data-on-submit="$ctrl.submitStep('step2', 'pci-project_vmadd_dc')"
                        data-valid="$ctrl.isStep2Valid()">
             <uib-tabset data-ng-show="!$ctrl.submitted.step2">
+                <!-- all regions -->
                 <uib-tab index="0" heading="{{ 'cpcivm_add_step2_tab_all' | translate }}">
                     <div class="cui-grid-list">
                         <div class="cui-grid-list-item cui-grid-cell"
@@ -182,21 +183,32 @@
                                                data-text="{{region.macroRegion.text}}"
                                                data-values="region.dataCenters"
                                                data-variant="light">
-                                <span class="oui-select-picker__section text-center"
-                                      data-ng-if="region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled">
-                                    <oui-button data-variant="link"
-                                                data-text="{{ 'cpcivm_add_step2_disabled_' + (region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled) | translate }}"
-                                                data-on-click="$ctrl.updateSshKeyRegion()"
-                                                data-ng-if="$ctrl.model.sshKey && ($ctrl.model.region.disabled === 'SSH_KEY' || (region.dataCenters.length === 1 && region.dataCenters[0].disabled === 'SSH_KEY'))">
-                                    </oui-button>
-                                    <span data-ng-bind="{{ ::'cpcivm_add_step2_disabled_' + region.disabled | translate }}"
-                                          data-ng-if="(region.dataCenters.length === 1 && region.dataCenters[0].disabled !== 'SSH_KEY') || $ctrl.model.region.disabled === 'SSH_KEY'">
-                                    </span>
-                                </span>
+                                <oui-select-picker-section
+                                    data-ng-if="region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled">
+                                    <div data-ng-switch="$ctrl.model.region.disabled || region.dataCenters[0].disabled">
+                                        <!-- region not activated, show link to activate it -->
+                                        <a class="oui-button oui-button_link"
+                                            data-ng-switch-when="INACTIVE"
+                                            data-ui-sref="iaas.pci-project.compute.regions">
+                                            <span data-ng-bind=" ::'cpci_add_regions_activate' | translate "></span>
+                                        </a>
+                                        <!-- SSH key not available for this region, show link to add the SSH key -->
+                                        <button type="button" class="oui-button oui-button_link"
+                                            data-ng-switch-when="SSH_KEY"
+                                            data-ng-click="$ctrl.updateSshKeyRegion()">
+                                            <span data-ng-bind=" ::'cpcivm_add_step2_disabled_SSH_KEY' | translate "></span>
+                                        </button>
+                                        <!-- show other message like instance, vram, vcup quota reached -->
+                                        <span data-ng-switch-default
+                                            data-ng-bind="::'cpcivm_add_step2_disabled_' + (region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled) | translate">
+                                        </span>
+                                    </div>
+                                </oui-select-picker-section>
                             </oui-select-picker>
                         </div>
                     </div>
                 </uib-tab>
+                <!-- regions by continent -->
                 <uib-tab data-ng-repeat="(continent, regions) in $ctrl.groupedRegions track by $index"
                          index="($index + 1)" heading="{{continent}}">
                     <div class="cui-grid-list">
@@ -213,17 +225,27 @@
                                                data-text="{{ region.macroRegion.text }}"
                                                data-values="region.dataCenters"
                                                data-variant="light">
-                                <span class="oui-select-picker__section text-center"
-                                      data-ng-if="region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled">
-                                    <oui-button data-variant="link"
-                                                data-text="{{ 'cpcivm_add_step2_disabled_' + (region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled) | translate }}"
-                                                data-on-click="$ctrl.updateSshKeyRegion()"
-                                                data-ng-if="$ctrl.model.sshKey && ($ctrl.model.region.disabled === 'SSH_KEY' || (region.dataCenters.length === 1 && region.dataCenters[0].disabled === 'SSH_KEY'))">
-                                    </oui-button>
-                                    <span data-ng-bind="{{ ::'cpcivm_add_step2_disabled_' + region.disabled | translate }}"
-                                          data-ng-if="(region.dataCenters.length === 1 && region.dataCenters[0].disabled !== 'SSH_KEY') || $ctrl.model.region.disabled === 'SSH_KEY'">
-                                    </span>
-                                </span>
+                                <oui-select-picker-section
+                                    data-ng-if="region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled">
+                                    <div data-ng-switch="$ctrl.model.region.disabled || region.dataCenters[0].disabled">
+                                        <!-- region not activated, show link to activate the button -->
+                                        <a class="oui-button oui-button_link"
+                                            data-ng-switch-when="INACTIVE"
+                                            data-ui-sref="iaas.pci-project.compute.regions">
+                                            <span data-ng-bind=" ::'cpci_add_regions_activate' | translate "></span>
+                                        </a>
+                                        <!-- SSH key not available for this region, show link to add the SSH key -->
+                                        <button type="button" class="oui-button oui-button_link"
+                                            data-ng-switch-when="SSH_KEY"
+                                            data-ng-click="$ctrl.updateSshKeyRegion()">
+                                            <span data-ng-bind=" ::'cpcivm_add_step2_disabled_SSH_KEY' | translate "></span>
+                                        </button>
+                                        <!-- show other message like instance, vram, vcup quota reached -->
+                                        <span data-ng-switch-default
+                                            data-ng-bind="::'cpcivm_add_step2_disabled_' + (region.dataCenters.length === 1 ? region.dataCenters[0].disabled : $ctrl.model.region.disabled) | translate">
+                                        </span>
+                                    </div>
+                                </oui-select-picker-section>
                             </oui-select-picker>
                         </div>
                     </div>

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.js
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/add/cloud-project-compute-infrastructure-virtualMachine-add.js
@@ -11,7 +11,10 @@ angular.module('managerApp').config(($stateProvider) => {
       },
     },
     translations: {
-      value: ['.'],
+      value: [
+        '.',
+        '../../../regions',
+      ],
       format: 'json',
     },
   });

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.controller.js
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.controller.js
@@ -86,6 +86,7 @@ angular.module('managerApp')
       CloudImageService,
       CucCloudMessage,
       CloudProjectComputeInfrastructureOrchestrator,
+      CucControllerHelper,
       OvhApiCloudProjectSshKey,
       OvhApiCloudProjectFlavor,
       OvhCloudPriceHelper,
@@ -99,6 +100,7 @@ angular.module('managerApp')
       OvhApiMe,
       ovhDocUrl,
       CucRegionService,
+      CucServiceHelper,
       CLOUD_FLAVOR_SPECIFIC_IMAGE,
       CLOUD_FLAVORTYPE_CATEGORY,
       CLOUD_INSTANCE_CPU_FREQUENCY,
@@ -653,6 +655,7 @@ angular.module('managerApp')
           // get flavors, gets the images (for windows image price calculation), get the quotas
           flavors: self.getFlavors(),
           regions: self.getRegions(),
+          availableRegions: self.getAvailableRegions(),
           sshKeys: self.getSshKeys(),
           hasVrack: CloudProjectComputeInfrastructureOrchestrator.hasVrack(),
           user: OvhApiMe.v6().get().$promise,
@@ -1655,6 +1658,18 @@ angular.module('managerApp')
             self.loaders.panelsData.regions = false;
           });
         }
+      };
+
+      // --------- AVAILABLE REGIONS panel ---------
+
+      self.getAvailableRegions = function getAvailableRegions() {
+        self.availableRegions = CucControllerHelper.request.getHashLoader({
+          loaderFunction: () => OvhApiCloudProjectRegion.AvailableRegions().v6()
+            .query({ serviceName })
+            .$promise
+            .catch(error => CucServiceHelper.errorHandler('cpci_add_regions_get_available_regions_error')(error)),
+        });
+        return self.availableRegions.load();
       };
 
       // --------- SSHKEYS panel ---------

--- a/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.html
+++ b/client/app/cloud/project/compute/infrastructure/virtualMachine/addEdit/cloud-project-compute-infrastructure-virtualMachine-addEdit.html
@@ -986,7 +986,7 @@
                                             class="pointer" role="button" tabindex="0" cuc-click-enter-on-keypress
                                             data-uib-tooltip="{{:: image.disabled ? ('cpcivm_addedit_image_disabled_' + image.disabled | translate) : (image.deprecated ? ('cpcivm_addedit_image_deprecated' | translate) : '') }}">
 
-                                            <td style="width: 50px;">
+                                            <td class="w-15">
                                                 <flat-radio>
                                                     <input type="radio" aria-hidden="true" tabindex="-1"
                                                            name="imagesChoice" id="{{::image.id}}"
@@ -996,7 +996,7 @@
                                                            data-ng-model="VmAddEditCtrl.model.imageId">
                                                 </flat-radio>
                                             </td>
-                                            <td class="no-space top-space-p8 bottom-space-p8" style="width: 50px;">
+                                            <td class="no-space top-space-p8 bottom-space-p8 w-15">
                                                 <img class="img-circle img-circle-bordered" width="50" height="50"
                                                      data-ng-src="assets/images/cloud/os/{{:: image.distribution}}_50.png"
                                                      alt="{{:: image.distribution }}" />
@@ -1037,7 +1037,7 @@
                                             class="pointer" role="button" tabindex="0" cuc-click-enter-on-keypress
                                             data-uib-tooltip="{{:: app.disabled ? ('cpcivm_addedit_image_disabled_' + app.disabled | translate) : (app.deprecated ? ('cpcivm_addedit_image_deprecated' | translate) : '') }}">
 
-                                            <td style="width: 50px;">
+                                            <td class="w-15">
                                                 <flat-radio>
                                                     <input type="radio" aria-hidden="true" tabindex="-1"
                                                            name="imagesChoice" id="{{::app.id}}"
@@ -1047,7 +1047,7 @@
                                                            data-ng-model="VmAddEditCtrl.model.imageId">
                                                 </flat-radio>
                                             </td>
-                                            <td class="no-space top-space-p8 bottom-space-p8" style="width: 50px;">
+                                            <td class="no-space top-space-p8 bottom-space-p8 w-15">
                                                 <img class="img-circle img-circle-bordered" width="50" height="50"
                                                      data-ng-src="assets/images/cloud/apps/{{:: app.applications[0] }}.png"
                                                      onerror="this.src='assets/images/cloud/apps/unknown.png'"
@@ -1094,7 +1094,7 @@
                                             class="pointer" role="button" tabindex="0" cuc-click-enter-on-keypress
                                             data-uib-tooltip="{{:: snapshot.disabled ? ('cpcivm_addedit_image_disabled_' + snapshot.disabled | translate) : (snapshot.deprecated ? ('cpcivm_addedit_image_deprecated' | translate) : '') }}">
 
-                                            <td style="width: 50px;">
+                                            <td class="w-15">
                                                 <flat-radio>
                                                     <input type="radio" aria-hidden="true" tabindex="-1"
                                                            name="imagesChoice" id="{{::snapshot.id}}"
@@ -1104,7 +1104,7 @@
                                                            data-ng-model="VmAddEditCtrl.model.imageId">
                                                 </flat-radio>
                                             </td>
-                                            <td class="no-space top-space-p8 bottom-space-p8" style="width: 50px;">
+                                            <td class="no-space top-space-p8 bottom-space-p8 w-15">
                                                 <div class="img-snapshot">
                                                     <i class="fa fa-{{snapshot.type}}"></i>
                                                 </div>
@@ -1183,12 +1183,12 @@
 
                                 <table class="table table-pretty table-hover table-striped shadow-z-1">
                                     <tbody>
-
+                                        <!-- activated regions -->
                                         <tr data-ng-repeat="region in VmAddEditCtrl.panelsData.regions"
                                             data-ng-click="VmAddEditCtrl.model.region = region"
                                             class="pointer" role="button" tabindex="0" cuc-click-enter-on-keypress>
 
-                                            <td style="width: 50px;">
+                                            <td class="w-15">
                                                 <flat-radio>
                                                     <input type="radio" aria-hidden="true" tabindex="-1"
                                                            name="regionsChoice" id="{{::region}}"
@@ -1197,7 +1197,7 @@
                                                            data-ng-model="VmAddEditCtrl.model.region">
                                                 </flat-radio>
                                             </td>
-                                            <td class="space-p8 flag-box flag-box-cell" style="width: 50px;">
+                                            <td class="space-p8 flag-box flag-box-cell w-15">
                                                 <div class="popover-list-item">
                                                     <div class="popover-list-item-illustration">
                                                         <i class="flag-icon {{:: VmAddEditCtrl.regionService.getRegionIconFlag(region) }} flag"></i>
@@ -1214,6 +1214,44 @@
                                                        data-ng-if="region | openStreetMap"
                                                        data-ng-click="$event.stopPropagation()">
                                                         {{ 'cloud_common_region_localize' | translate }}<i class="fa fa-map-marker fs14 left-space-m4"></i>
+                                                    </a>
+                                                </span>
+                                            </td>
+                                        </tr>
+                                        <!-- available but not activated regions -->
+                                        <tr data-ng-repeat="region in VmAddEditCtrl.availableRegions.data track by region.name"
+                                            class="cursor-disabled"
+                                            data-ng-if="!VmAddEditCtrl.availableRegions.loading && VmAddEditCtrl.availableRegions.data.length > 0">
+                                            <td class="w-15">
+                                                <flat-radio>
+                                                    <input type="radio" aria-hidden="true" tabindex="-1"
+                                                           name="regionsChoice" id="{{::region.name}}"
+                                                           data-ovh-stop-event="click"
+                                                           disabled="true"
+                                                           value="{{::region.name}}">
+                                                </flat-radio>
+                                            </td>
+                                            <td class="space-p8 flag-box flag-box-cell w-15">
+                                                <div class="popover-list-item">
+                                                    <div class="popover-list-item-illustration">
+                                                        <i class="flag-icon {{:: VmAddEditCtrl.regionService.getRegionIconFlag(region.name) }} flag"></i>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td class="left-space-p4">
+                                                <span class="fs14 no-space normal col-xs-12" data-ng-bind="::VmAddEditCtrl.regionService.getTranslatedMicroRegion(region.name)"></span>
+                                                <span class="fs10 no-space col-xs-12">
+                                                    {{ VmAddEditCtrl.regionService.getTranslatedMicroRegionLocation(region.name) }}
+                                                    <a class="left-space-m8"
+                                                       href="{{ region.name | openStreetMap }}"
+                                                       target="_blank"
+                                                       data-ng-if="region.name | openStreetMap"
+                                                       data-ng-click="$event.stopPropagation()">
+                                                        {{ 'cloud_common_region_localize' | translate }}<i class="fa fa-map-marker fs14 left-space-m4"></i>
+                                                    </a>
+                                                    <a class="left-space-m8"
+                                                        data-ui-sref="iaas.pci-project.compute.regions">
+                                                        <span data-ng-bind=" ::'cpci_add_regions_activate' | translate "></span>
                                                     </a>
                                                 </span>
                                             </td>
@@ -1434,9 +1472,9 @@
                                data-ng-if="!VmAddEditCtrl.projectHasNoSshKeys()">
                             <thead>
                                 <tr>
-                                    <th style="width: 50px;"></th>
+                                    <th class="w-15"></th>
                                     <th data-translate="cpcivm_addedit_sshkey_name"></th>
-                                    <th class="text-center" style="width: 50px;">
+                                    <th class="text-center w-15">
                                         <button class="no-style" type="button"
                                             data-ng-click="VmAddEditCtrl.getSshKeys(true)"
                                             title="{{:: 'cpcivm_addedit_sshkey_refresh_button' | translate}}">

--- a/client/app/cloud/project/compute/infrastructure/volume/addEdit/cloud-project-compute-infrastructure-volume-addEdit.controller.js
+++ b/client/app/cloud/project/compute/infrastructure/volume/addEdit/cloud-project-compute-infrastructure-volume-addEdit.controller.js
@@ -1,11 +1,13 @@
 angular.module('managerApp')
   .controller('CloudProjectComputeInfrastructureVolumeAddEditCtrl',
     function CloudProjectComputeInfrastructureVolumeAddEditCtrl(
-      $scope, CloudProjectComputeVolumesOrchestrator, $rootScope, $timeout,
-      OvhApiCloudProjectRegion, $translate,
-      CucCloudMessage, $stateParams, CLOUD_VOLUME_TYPES, OvhApiCloudProjectQuota,
-      $location, atInternet, OvhApiMe, CucRegionService,
-      CLOUD_VOLUME_MAX_SIZE, CLOUD_VOLUME_MIN_SIZE, CLOUD_VOLUME_UNLIMITED_QUOTA,
+      $rootScope, $scope, $stateParams, $timeout, $translate,
+      atInternet, CloudProjectComputeVolumesOrchestrator,
+      CucServiceHelper, CucControllerHelper,
+      CucRegionService, CucCloudMessage,
+      OvhApiCloudProjectRegion, OvhApiCloudProjectQuota,
+      CLOUD_VOLUME_TYPES, CLOUD_VOLUME_MAX_SIZE,
+      CLOUD_VOLUME_MIN_SIZE, CLOUD_VOLUME_UNLIMITED_QUOTA,
     ) {
       const self = this;
 
@@ -57,6 +59,7 @@ angular.module('managerApp')
 
       function init() {
         self.getRegions();
+        self.getAvailableRegions();
 
         self.volumeInEditionParam = CloudProjectComputeVolumesOrchestrator.getEditVolumeParam();
         CloudProjectComputeVolumesOrchestrator.setEditVolumeParam(null);
@@ -212,6 +215,18 @@ angular.module('managerApp')
             self.loaders.panelsData.regions = false;
           });
         }
+      };
+
+      // --------- available REGIONS panel ---------
+
+      self.getAvailableRegions = function getAvailableRegions() {
+        self.availableRegions = CucControllerHelper.request.getHashLoader({
+          loaderFunction: () => OvhApiCloudProjectRegion.AvailableRegions().v6()
+            .query({ serviceName })
+            .$promise
+            .catch(error => CucServiceHelper.errorHandler('cpci_add_regions_get_available_regions_error')(error)),
+        });
+        return self.availableRegions.load();
       };
 
       $scope.$watch('VolumeAddEditCtrl.volumeInEdition.region', (value, oldValue) => {

--- a/client/app/cloud/project/compute/infrastructure/volume/addEdit/cloud-project-compute-infrastructure-volume-addEdit.html
+++ b/client/app/cloud/project/compute/infrastructure/volume/addEdit/cloud-project-compute-infrastructure-volume-addEdit.html
@@ -436,7 +436,7 @@
                         <div class="popover-detail-item">
                             <table class="table table-pretty table-hover table-striped shadow-z-1 no-space">
                                 <tbody>
-
+                                    <!-- regions -->
                                     <tr data-ng-repeat="region in VolumeAddEditCtrl.panelsData.regions"
                                         data-ng-click="VolumeAddEditCtrl.volumeInEdition.region = region"
                                         class="pointer" role="button" tabindex="0" cuc-click-enter-on-keypress>
@@ -469,7 +469,41 @@
                                             </div>
                                         </td>
                                     </tr>
-
+                                    <!-- available regions but not activated -->
+                                    <tr data-ng-repeat="region in VolumeAddEditCtrl.availableRegions.data"
+                                        style="cursor: not-allowed;"
+                                        data-ng-if="!VolumeAddEditCtrl.availableRegions.loading && VolumeAddEditCtrl.availableRegions.data.length > 0">
+                                        <td style="width: 50px; vertical-align: middle">
+                                            <flat-radio>
+                                                <input type="radio" aria-hidden="true" tabindex="-1"
+                                                       name="regionsChoice" id="{{ ::region.name }}"
+                                                       value="{{ ::region.name }}"
+                                                       disabled="true">
+                                            </flat-radio>
+                                        </td>
+                                        <td class="space-p8 flag-box flag-box-cell">
+                                            <div class="popover-list-item popover-box top-space-m4">
+                                                <div class="popover-list-item-illustration box-left">
+                                                    <i class="flag-icon {{ ::VolumeAddEditCtrl.regionService.getRegionIconFlag(region.name) }} flag"></i>
+                                                </div>
+                                                <div class="box-right text-left">
+                                                    <h3 class="fs14 no-space normal" data-ng-bind="::VolumeAddEditCtrl.regionService.getTranslatedMicroRegion(region.name)"></h3>
+                                                    <h4 class="fs10 no-space normal" data-ng-bind="::VolumeAddEditCtrl.regionService.getTranslatedMicroRegionLocation(region.name)"></h4>
+                                                    <a class="fs10"
+                                                       href="{{ region.name | openStreetMap }}"
+                                                       target="_blank"
+                                                       data-ng-if="region.name | openStreetMap"
+                                                       data-ng-click="$event.stopPropagation()">
+                                                        {{ 'cloud_common_region_localize' | translate }}<i class="fa fa-map-marker left-space-m4"></i>
+                                                    </a>
+                                                    <a class="left-space-m8"
+                                                        data-ui-sref="iaas.pci-project.compute.regions">
+                                                        <span data-ng-bind=" ::'cpci_add_regions_activate' | translate "></span>
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
                                 </tbody>
                             </table>
                         </div>

--- a/client/app/cloud/project/compute/quota/cloud-project-compute-quota.controller.js
+++ b/client/app/cloud/project/compute/quota/cloud-project-compute-quota.controller.js
@@ -4,7 +4,8 @@ angular.module('managerApp').controller('CloudProjectComputeQuotaCtrl',
   function CloudProjectComputeQuotaCtrl(
     $q, $stateParams, $translate, REDIRECT_URLS,
     OvhApiCloudProject, OvhApiCloudProjectQuota, OvhApiMe, CucCloudMessage, OtrsPopupService,
-    CucRegionService, TARGET,
+    CucRegionService, CucControllerHelper,
+    CucServiceHelper, OvhApiCloudProjectRegion, TARGET,
   ) {
     // ---------VARIABLE DECLARATION---------
 
@@ -43,6 +44,16 @@ angular.module('managerApp').controller('CloudProjectComputeQuotaCtrl',
       }
     };
 
+    function getAvailableRegions() {
+      self.availableRegions = CucControllerHelper.request.getHashLoader({
+        loaderFunction: () => OvhApiCloudProjectRegion.AvailableRegions().v6()
+          .query({ serviceName })
+          .$promise
+          .catch(error => CucServiceHelper.errorHandler('cpci_add_regions_get_available_regions_error')(error)),
+      });
+      return self.availableRegions.load();
+    }
+
     // ---------UNLEASH---------
 
     function initPaymentMethods() {
@@ -69,7 +80,8 @@ angular.module('managerApp').controller('CloudProjectComputeQuotaCtrl',
 
       self.loader.quota = true;
       self.loader.unleash = false;
-
+      // load available regions
+      getAvailableRegions();
       // check default payment mean
       initQueue.push(initPaymentMethods().then((defaultPaymentMean) => {
         self.datas.defaultPaymentMean = defaultPaymentMean;

--- a/client/app/cloud/project/compute/quota/cloud-project-compute-quota.html
+++ b/client/app/cloud/project/compute/quota/cloud-project-compute-quota.html
@@ -123,6 +123,30 @@
             </oui-column>
         </oui-datagrid>
 
+        <!-- QUOTA TABLE -->
+        <strong>{{ ::'cpci_add_regions_inactive' | translate }}</strong>
+
+        <oui-datagrid data-rows="CloudProjectComputeQuotaCtrl.availableRegions.data"
+            data-loading="CloudProjectComputeQuotaCtrl.availableRegions.loading">
+            <oui-column data-title="::'cloud_common_region' | translate" data-property="name" data-sortable="asc">
+                <div class="flag-box">
+                    <div class="flag-wrapper inline-block vertical-middle">
+                        <span class="flag-icon {{ :: CloudProjectComputeQuotaCtrl.regionService.getRegionIconFlag($row.name) }} flag" aria-hidden="true"></span>
+                    </div>
+                    <div class="flag-text inline-block left-space-m8 top-space-m8 vertical-middle">
+                        {{ :: CloudProjectComputeQuotaCtrl.regionService.getTranslatedMicroRegion($row.name) }}
+                    </div>
+                </div>
+            </oui-column>
+            <oui-action-menu data-align="end" data-compact>
+                <oui-action-menu-item>
+                    <a class="oui-button oui-button_link"
+                        data-ui-sref="iaas.pci-project.compute.regions">
+                        <span data-translate="cpci_add_regions_activate"></span>
+                    </a>
+                </oui-action-menu-item>
+            </oui-action-menu>
+        </oui-datagrid>
     </div>
 
 </div>

--- a/client/app/cloud/project/compute/quota/cloud-project-compute-quota.js
+++ b/client/app/cloud/project/compute/quota/cloud-project-compute-quota.js
@@ -11,7 +11,10 @@ angular.module('managerApp').config(($stateProvider) => {
       },
     },
     translations: {
-      value: ['.'],
+      value: [
+        '.',
+        '../regions',
+      ],
       format: 'json',
     },
   });

--- a/client/app/cloud/project/compute/regions/translations/Messages_fr_FR.json
+++ b/client/app/cloud/project/compute/regions/translations/Messages_fr_FR.json
@@ -1,5 +1,7 @@
 {
   "cpci_add_regions_title": "Ajouter des régions",
+  "cpci_add_regions_inactive": "Régions inactives",
+  "cpci_add_regions_activate": "Activer cette région",
   "cpci_add_regions_description": "OVH vous propose plusieurs régions pour créer vos infrastructures ou créer un conteneur. Par défaut vous avez accès à quelques régions mais vous pouvez choisir d'ajouter de nouvelles régions.",
   "cpci_add_regions_added_title": "Régions disponibles",
   "cpci_add_regions_available_to_add_title": "Régions que vous pouvez ajouter",

--- a/client/app/cloud/project/storage/storage-add/storage/add-storage-controller.js
+++ b/client/app/cloud/project/storage/storage-add/storage/add-storage-controller.js
@@ -8,8 +8,11 @@ angular.module('managerApp').controller('RA.add.storageCtrl', [
   'OvhApiCloudProjectRegion',
   'CloudStorageContainers',
   'CucCloudMessage',
+  'CucControllerHelper',
+  'CucServiceHelper',
   function storageCtrl($q, $scope, $state, $stateParams, $timeout, $translate,
-    OvhApiCloudProjectRegion, CloudStorageContainers, CucCloudMessage) {
+    OvhApiCloudProjectRegion, CloudStorageContainers, CucCloudMessage,
+    CucControllerHelper, CucServiceHelper) {
     $scope.projectId = $stateParams.projectId;
 
     $scope.model = {};
@@ -98,8 +101,19 @@ angular.module('managerApp').controller('RA.add.storageCtrl', [
         });
     }
 
+    function getAvailableRegions() {
+      $scope.availableRegions = CucControllerHelper.request.getHashLoader({
+        loaderFunction: () => OvhApiCloudProjectRegion.AvailableRegions().v6()
+          .query({ serviceName: $scope.projectId })
+          .$promise
+          .catch(error => CucServiceHelper.errorHandler('cpci_add_regions_get_available_regions_error')(error)),
+      });
+      return $scope.availableRegions.load();
+    }
+
     function init() {
       loadMessage();
+      getAvailableRegions();
       return loadRegions()
         .then(() => {
           $scope.loadStep('region');

--- a/client/app/cloud/project/storage/storage-add/storage/step_region/add-storage-step-region.html
+++ b/client/app/cloud/project/storage/storage-add/storage/step_region/add-storage-step-region.html
@@ -17,5 +17,26 @@
                                data-variant="light">
             </oui-select-picker>
         </div>
+        <!-- available but not activated regions -->
+        <div class="cui-grid-list-item cui-grid-cell"
+             data-ng-if="!availableRegions.loading && availableRegions.data.length > 0"
+             data-ng-repeat="region in availableRegions.data track by $index">
+            <oui-select-picker data-id="region_{{ region.name }}"
+                               data-name="region_{{ region.name }}"
+                               data-values="[region.name]"
+                               data-picture="storage-region-flag flag-icon {{:: regionService.getRegionIconFlag(region.name) }} flag"
+                               data-text="{{:: regionService.getTranslatedMicroRegion(region.name)}}"
+                               data-on-change="clickOnRegion(region.name)"
+                               data-variant="light"
+                               data-disabled="true">
+                <oui-select-picker-section>
+                    <!-- region not activated, show link to activate it -->
+                    <a class="oui-button oui-button_link"
+                        data-ui-sref="iaas.pci-project.compute.regions">
+                        <span data-translate="cpci_add_regions_activate"></span>
+                    </a>
+                </oui-select-picker-section>
+            </oui-select-picker>
+        </div>
     </div>
 </div>

--- a/client/app/cloud/project/storage/storage.js
+++ b/client/app/cloud/project/storage/storage.js
@@ -32,6 +32,7 @@ angular.module('managerApp')
           value: [
             '.',
             '../storage/storage-add',
+            '../compute/regions',
           ],
           format: 'json',
         },


### PR DESCRIPTION
show all regions, active and inactive, while creating server during region selection. If the region is inactive, disable it and show a link to activate it.

Closes #MBP-377

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
Show all available/inactive regions ()improve regions activation

### Description of the Change
While creating a server in PCI, only regions available and activated are shown. Regions like APAC(Singapore and Australia) are not shown because they are not activated. There is a regions page which can be used to activate these regions. Once they are activated, they will be shown.  The enhancement is to show unactivated regions also with the disabled state so the user can not select them. Also, provide a link on them to activate it. This will better inform users about new and inactive regions that they can use. This change is done in below pages
1. Diagram, create server
2. List, create server
3. Diagram, create storage
4. Create containers page
5. PCI Quota page

### Benefits

<!-- optional -->
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
MBP-377
