### PR TITLE
fix(servers-storage): loader visibility

### DIFF
--- a/client/app/cloud/project/storage/storage.html
+++ b/client/app/cloud/project/storage/storage.html
@@ -2,9 +2,11 @@
 
     <cui-message-container data-messages="messages"></cui-message-container>
 
-    <cui-page-content-title data-text="'storage_title' | translate">
-        <oui-spinner data-ng-show="loaders.storages"></oui-spinner>
-    </cui-page-content-title>
+    <cui-page-content-title data-text="'storage_title' | translate"></cui-page-content-title>
+
+    <div class="text-center" data-ng-if="loaders.storages">
+        <oui-spinner></oui-spinner>
+    </div>
 
     <div data-ng-if="storages !== null">
         <a class="oui-button oui-button_secondary"


### PR DESCRIPTION
Close MBP-386

### Requirements

The loader is not visible, resulting in a blank page, until the data in the Storage page loads

## Storage Loader fix


### Description of the Change

The reason for this issue is that the loader is present inside the cui-page-content-title tag in the html code. This has been fixed by moving the loader outside the cui-page-content-title tag.