### PR TITLE
fix(kubernetes): display modals

### DIFF
--- a/client/app/kubernetes/service/kubernetes-service.controller.js
+++ b/client/app/kubernetes/service/kubernetes-service.controller.js
@@ -107,7 +107,7 @@ angular.module('managerApp').controller('KubernetesServiceCtrl', class Kubernete
   }
 
   showUgradePolicy() {
-    this.ControllerHelper.modal.showModal({
+    this.CucControllerHelper.modal.showModal({
       modalConfig: {
         templateUrl: 'app/kubernetes/service/upgrade-policy/kubernetes-service-upgrade-policy.html',
         controller: 'kubernetesUpgradePolicyCtrl',

--- a/client/app/kubernetes/service/update/kubernetes-service-update.controller.js
+++ b/client/app/kubernetes/service/update/kubernetes-service-update.controller.js
@@ -1,13 +1,13 @@
 class kubernetesUpdateCtrl {
   /* @ngInject */
   constructor($rootScope, $stateParams, $translate, $uibModalInstance, CucCloudMessage,
-    ControllerHelper, Kubernetes) {
+    CucControllerHelper, Kubernetes) {
     this.$rootScope = $rootScope;
     this.serviceName = $stateParams.serviceName;
     this.$uibModalInstance = $uibModalInstance;
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
-    this.ControllerHelper = ControllerHelper;
+    this.CucControllerHelper = CucControllerHelper;
     this.Kubernetes = Kubernetes;
   }
 
@@ -22,14 +22,14 @@ class kubernetesUpdateCtrl {
   update() {
     this.loading = true;
     this.CucCloudMessage.flushChildMessage();
-    this.updating = this.ControllerHelper.request.getHashLoader({
+    this.updating = this.CucControllerHelper.request.getHashLoader({
       loaderFunction: () => this.Kubernetes
         .updateKubernetesVersion(this.serviceName)
         .then(() => this.CucCloudMessage.success(this.$translate.instant('kube_service_update_success')))
         .catch(err => this.CucCloudMessage.error(this.$translate.instant('kube_service_update_error', { message: _.get(err, 'data.message', '') })))
         .finally(() => {
           this.loading = false;
-          this.ControllerHelper.scrollPageToTop();
+          this.CucControllerHelper.scrollPageToTop();
           this.$uibModalInstance.close();
           this.$rootScope.$broadcast('kube.service.refresh');
         }),

--- a/client/app/kubernetes/service/update/kubernetes-service-update.modal.controller.js
+++ b/client/app/kubernetes/service/update/kubernetes-service-update.modal.controller.js
@@ -1,15 +1,15 @@
 class kubernetesUpdateModalCtrl {
   /* @ngInject */
-  constructor($scope, $state, $stateParams, ControllerHelper) {
+  constructor($scope, $state, $stateParams, CucControllerHelper) {
     this.$scope = $scope;
     this.$state = $state;
     this.serviceName = $stateParams.serviceName;
-    this.ControllerHelper = ControllerHelper;
+    this.CucControllerHelper = CucControllerHelper;
     this.openModal();
   }
 
   openModal() {
-    this.ControllerHelper.modal.showModal({
+    this.CucControllerHelper.modal.showModal({
       modalConfig: {
         templateUrl: 'app/kubernetes/service/update/kubernetes-service-update.html',
         controller: 'kubernetesUpdateCtrl',

--- a/client/app/kubernetes/service/upgrade-policy/kubernetes-service-upgrade-policy.controller.js
+++ b/client/app/kubernetes/service/upgrade-policy/kubernetes-service-upgrade-policy.controller.js
@@ -1,11 +1,11 @@
 class kubernetesUpgradePolicyCtrl {
   constructor($stateParams, $translate, $uibModalInstance, CucCloudMessage,
-    ControllerHelper, Kubernetes, upgradePolicy) {
+    CucControllerHelper, Kubernetes, upgradePolicy) {
     this.serviceName = $stateParams.serviceName;
     this.$uibModalInstance = $uibModalInstance;
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
-    this.ControllerHelper = ControllerHelper;
+    this.CucControllerHelper = CucControllerHelper;
     this.Kubernetes = Kubernetes;
     this.selectedUpgradePolicy = upgradePolicy;
     this.upgradePolicies = this.Kubernetes.getUpgradePolicies();
@@ -27,7 +27,7 @@ class kubernetesUpgradePolicyCtrl {
    */
   updateUpgradePolicy() {
     this.CucCloudMessage.flushChildMessage();
-    this.save = this.ControllerHelper.request.getHashLoader({
+    this.save = this.CucControllerHelper.request.getHashLoader({
       loaderFunction: () => this.Kubernetes
         .updateKubernetesUpgradePolicy(this.serviceName, this.selectedUpgradePolicy)
         .then(() => this.CucCloudMessage.success(
@@ -35,7 +35,7 @@ class kubernetesUpgradePolicyCtrl {
         ))
         .catch(err => this.CucCloudMessage.error(this.$translate.instant('kube_service_upgrade_policy_error', { message: _.get(err, 'data.message', '') })))
         .finally(() => {
-          this.ControllerHelper.scrollPageToTop();
+          this.CucControllerHelper.scrollPageToTop();
           this.$uibModalInstance.close(this.selectedUpgradePolicy);
         }),
     });


### PR DESCRIPTION
## fix(kubernetes): display modals

### Description of the Change

* update `kubernetes` module to use `CucControllerHelper` instead of
`ControllerHelper`

1710ec40 — fix(kubernetes): display modals

ref: MBP-393

/cc @jleveugle @frenautvh @antleblanc