### PR TITLE
fix(deps): upgrade ng-ovh-otrs to v7.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@ovh-ux/ng-ovh-doc-url": "^1.0.0",
     "@ovh-ux/ng-ovh-form-flat": "^4.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
-    "@ovh-ux/ng-ovh-otrs": "^7.0.2",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.4",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",
     "@ovh-ux/ng-ovh-sidebar-menu": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,10 +1133,10 @@
     lodash "~4.17.11"
     urijs "^1.19.1"
 
-"@ovh-ux/ng-ovh-otrs@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.0.2.tgz#1406d17e64a920e6cf5be2950ba0acc1aaa364a1"
-  integrity sha512-2e9TyXilq3PX+V9vgzjx5m6Q/JAE3MyFACfulFFiaqJRWtci2QmeZbTdPo1jqlYH1op79j0qTVzt0KZe3CG1pQ==
+"@ovh-ux/ng-ovh-otrs@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.4.tgz#e49c9696dc9a86281ae4bd3f71c43c1fc4a7a36c"
+  integrity sha512-z+h5clMBoB/9Mxd+k15PLkeZMKQbDKpoPfztaPhcHJBsaK9aJWUZPN2YdxOc1Im4dWkWI4soPF+zI1wFdQGBhA==
   dependencies:
     draggable "^4.2.0"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade ng-ovh-otrs to v7.1.4

### :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-otrs@7.1.4

### :house: Internal

- No QC required.