### PR TITLE
fix(deps): upgrade ng-ovh-otrs to v7.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@ovh-ux/ng-ovh-doc-url": "^1.0.0",
     "@ovh-ux/ng-ovh-form-flat": "^4.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.4",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.5",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",
     "@ovh-ux/ng-ovh-sidebar-menu": "^8.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,10 +1133,10 @@
     lodash "~4.17.11"
     urijs "^1.19.1"
 
-"@ovh-ux/ng-ovh-otrs@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.4.tgz#e49c9696dc9a86281ae4bd3f71c43c1fc4a7a36c"
-  integrity sha512-z+h5clMBoB/9Mxd+k15PLkeZMKQbDKpoPfztaPhcHJBsaK9aJWUZPN2YdxOc1Im4dWkWI4soPF+zI1wFdQGBhA==
+"@ovh-ux/ng-ovh-otrs@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.5.tgz#704977ed49f2af18f1c132a4aaecf0513b411c5c"
+  integrity sha512-rZACe9m+do4vRqgV2AOulFKVIWsZiwY3tTc6iI9P7PIZcbpyqOzcnJlPrA96sfHiRV+bBcCnfvuwKSmS8Dig5g==
   dependencies:
     draggable "^4.2.0"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade ng-ovh-otrs to v7.1.5

## :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-otrs@7.1.5

## :house: Internal

- No QC required.