### PR TITLE
fix(metrics-tokens-create): handle empty label

### DIFF
--- a/client/app/dbaas/dbaas-metrics/token/add/metrics-token-add.controller.js
+++ b/client/app/dbaas/dbaas-metrics/token/add/metrics-token-add.controller.js
@@ -45,7 +45,7 @@
     }
 
     static checkLabel(label) {
-      return (label.key !== null && label.value !== null);
+      return (!!label.key && label.value !== null);
     }
 
     checkLabels() {


### PR DESCRIPTION
MBP-402

### Requirements

When the user types into the label field and then erases it while trying to create a token, the API errors out saying the label cannot be empty.

## Metrics Token creation bug fix

### Description of the Change

Fixed this issue by checking for empty label