### PR TITLE
build(deps): upgrade ovh-api-services to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ovh-angular-slider": "ovh-ux/ovh-angular-slider#^0.2.2",
     "ovh-angular-tail-logs": "ovh-ux/ovh-angular-tail-logs#^1.1.2",
     "ovh-angular-toaster": "ovh-ux/ovh-angular-toaster#^0.8.0",
-    "ovh-api-services": "^6.30.0",
+    "ovh-api-services": "^7.0.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7977,10 +7977,10 @@ ovh-angular-toaster@ovh-ux/ovh-angular-toaster#^0.8.0:
   version "0.8.0"
   resolved "https://codeload.github.com/ovh-ux/ovh-angular-toaster/tar.gz/06d24889e94b8d816afee8e94185697cf68f2338"
 
-ovh-api-services@^6.30.0:
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.30.0.tgz#d02a5eda1878911077721a3677d1ba598d572f4c"
-  integrity sha512-JmtAkRQTE8Ky5h6Y50YTHjH4AUt7omEkeEBoNk6G+ytHuJhjHFfUgR2JsRt2V1W7OcZrHjRWC6yDrrFU6LYU3g==
+ovh-api-services@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-7.0.0.tgz#240ced6f8930eed94b4484aa558ad8f432af537f"
+  integrity sha512-aC2NDo9Rf7iwJvfnoPJ2E9Rtrv7Yy7tNXFJv4PifBqyUefjbTAUCfDNRrxgVnpOmPJ1h5SWjx19t3T/6w8qVDw==
   dependencies:
     lodash "^3.10.1"
 


### PR DESCRIPTION
# Upgrade ovh-api-services to v7.0.0

## :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- ovh-api-services@7.0.0

## :link: Related

- ovh-ux/ovh-api-services#191

## :house: Internal

- No QC required.