### PR TITLE
fix(cloud.logs): allow to create an index again

### DIFF
--- a/client/app/dbaas/logs/detail/index/logs-index.service.js
+++ b/client/app/dbaas/logs/detail/index/logs-index.service.js
@@ -94,6 +94,7 @@ class LogsIndexService {
       {
         alertNotifyEnabled: object.alertNotifyEnabled,
         optionId: object.optionId,
+        description: object.description,
         suffix: object.suffix,
       }).$promise
       .then((operation) => {


### PR DESCRIPTION
Hello,

This PR will fix a regression on index creation.

Internal ticket: OB-2315

Please consider to merge it asap as it currently make feature unusable.

As always, thanks you for your review, merge & prod time.